### PR TITLE
set publish environment to testpypi for test

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
     name: upload release to PyPI
     runs-on: ubuntu-latest
     # Specifying a GitHub environment is optional, but strongly encouraged
-    environment: pypi
+    environment: testpypi
     permissions:
       # IMPORTANT: this permission is mandatory for Trusted Publishing
       id-token: write


### PR DESCRIPTION
Trying to get the publish workflow to work (on testpypi first), setting the `environment` to `testpypi`.