### PR TITLE
Publish to PyPi as kensho-kfinance

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
     name: upload release to PyPI
     runs-on: ubuntu-latest
     # Specifying a GitHub environment is optional, but strongly encouraged
-    environment: testpypi
+    environment: pypi
     permissions:
       # IMPORTANT: this permission is mandatory for Trusted Publishing
       id-token: write

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -39,5 +39,3 @@ jobs:
       run: python -m build
     - name: Publish package distributions to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/

--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.0.0
+- Initial public release
+
 ## v0.99.1
 - Update llm tools to use identifier instead of ticker
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "kfinance"
+name = "kensho-kfinance"
 dynamic = ["version"]
 authors = [
   { name="Luke Brown", email="luke.brown@kensho.com" },


### PR DESCRIPTION
`kfinance` as a package name was already reserved. 