### PR TITLE
Fix the readthedocs configuration (1st try)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
   # https://docs.readthedocs.com/platform/stable/build-customization.html#avoid-having-a-dirty-git-index
   jobs:
     pre_install:
-      - git update-index --assume-unchanged kfinance/version.py docs/conf.py
+      - git update-index --assume-unchanged docs/conf.py
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Readthedocs is now integrated with the kfinance repo, and it only tries to build the latest branch (main) and the stable branch (whatever gets released).

The `latest` branch build is broken because `kfinance/version.py` doesn't exist in it (because it's built by `setuptools-scm`). So this change should unblock that. 

The `stable` branch is currently broken as well, because the last-released version of `kensho-kfinance` doesn't have the `.readthedocs.yaml` configuration file in it. We'll get the latest branch build to work first, and then we can release a new version just for the documentation purpose and it should get fixed.

Hopefully this is the only PR I'll need to get readthedocs to be fixed. Then the next time we open-source a new project we won't have this try-and-try-again approach.