### PR TITLE
Add pydantic and tabulate as dependencies

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## v1.2.2
+- Add tabulate and pydantic as dependencies
+
 ## v1.2.1
 - Add fetch for industry_code, industry_classification and gics_code.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,17 +16,20 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
+
 dependencies = [
-    "python-dateutil>=2.8.2,<2.9",
-    "requests>=2.22.0,<3",
-    "urllib3>=1.21.1",
-    "pyjwt>=2.8.0",
+    "langchain-core>=0.3.15",
     "numpy>=1.22.4",
     "pandas>=2.0.0",
-    "types-requests>=2.22.0,<3",
     "pillow>=10",
-    "langchain-core>=0.3.15",
+    "pydantic>=2.10.0,<3",
+    "pyjwt>=2.8.0",
+    "python-dateutil>=2.8.2,<2.9",
     "strenum>=0.4.15",
+    "tabulate>=0.9.0",  # required for turning dataframes into markdown
+    "types-requests>=2.22.0,<3",
+    "requests>=2.22.0,<3",
+    "urllib3>=1.21.1",
 ]
 
 [project.optional-dependencies]
@@ -35,8 +38,8 @@ dev = [
     "mypy>=1.15.0,<2",
     "pytest>=6.1.2,<7",
     "pytest-cov>=6.0.0,<7",
-    "ruff>=0.9.4,<1",
     "requests_mock>=1.1,<1.2",
+    "ruff>=0.9.4,<1",
 ]
 
 [project.urls]


### PR DESCRIPTION
Add pydantic and tabulate as dependencies. 

We missed the tabulate dependency (for df.to_markdown()) and pydantic was installed as a dependency of langchain-core rather than as a direct dependency.