### PR TITLE
Separate out step to build tool calling documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,13 +3,15 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
-    # You can also specify other tool versions:
-    # nodejs: "16"
-  # borrowed from here:
-  # https://docs.readthedocs.com/platform/stable/build-customization.html#avoid-having-a-dirty-git-index
   jobs:
     pre_install:
+      # borrowed from here:
+      # https://docs.readthedocs.com/platform/stable/build-customization.html#avoid-having-a-dirty-git-index
       - git update-index --assume-unchanged docs/conf.py
+    tool_calling_pre_processing:
+      # build documentation for tool calling before generating docs.
+      - pip install langchain-core
+      - python docs/build_tool_calling_documentation.py
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/build_tool_calling_documentation.py
+++ b/docs/build_tool_calling_documentation.py
@@ -1,5 +1,5 @@
-import inspect
 from enum import Enum
+import inspect
 from pathlib import Path
 
 from langchain_core.utils.function_calling import convert_to_openai_tool
@@ -48,11 +48,7 @@ def add_function_to_tools_file(tool: KfinanceTool) -> None:
     """
 
     # The signature built with the inspect module does not include necessary imports.
-    imports = [
-        "import kfinance",
-        "import datetime",
-        "from typing import Optional"
-    ]
+    imports = ["import kfinance", "import datetime", "from typing import Optional"]
     signature_str = build_signature_str(tool)
 
     # Use inspect to retrieve the return type and add it to the imports if it's not a builtin.
@@ -66,10 +62,6 @@ def add_function_to_tools_file(tool: KfinanceTool) -> None:
     for field_name, field_metadata in tool.args_schema.model_fields.items():
         # We use the openai definition to extract the field description. This means that, just like
         # pydantic/langchain, we use the docstring of an enum as the description for an enum field.
-        try:
-            openai_params[field_name]['description']
-        except:
-            assert False, tool.name
         args += f"\n    :param {field_name}: {openai_params[field_name]['description']}"
         args += f"\n    :type {field_name}: {display_as_type(field_metadata.annotation)}"
 
@@ -84,7 +76,8 @@ def add_function_to_tools_file(tool: KfinanceTool) -> None:
     with open(inspect.getfile(tool.__class__), mode="a") as f:
         f.write(func_str)
 
-def build_signature_str(tool) -> str:
+
+def build_signature_str(tool: KfinanceTool) -> str:
     """Return the signature string of the tool
 
     Return value example:
@@ -104,7 +97,6 @@ def build_signature_str(tool) -> str:
     return f"def {tool.name}{signature}:"
 
 
-
 def add_module_to_tool_calling_rst(tool: KfinanceTool) -> None:
     """Add a module for each tool to tool_calling.rst.
 
@@ -121,3 +113,6 @@ def add_module_to_tool_calling_rst(tool: KfinanceTool) -> None:
 
     with open(Path(Path(__file__).resolve().parent, "tool_calling.rst"), mode="a") as f:
         f.write(module_str)
+
+if __name__ == "__main__":
+    add_tool_calling_docs_for_all_tools()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,15 +7,10 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 from importlib.metadata import version as get_version
 
-from docs.build_tool_calling_documentation import add_tool_calling_docs_for_all_tools
-
-
 project = "kensho-kfinance"
 copyright = "2025, Kensho Technologies"
 author = "Kensho Technologies"
 
-# Add documentation for tool calling.
-add_tool_calling_docs_for_all_tools()
 
 # borrowed from here:
 # https://setuptools-scm.readthedocs.io/en/latest/usage/#usage-from-sphinx
@@ -57,7 +52,6 @@ templates_path = ["templates"]
 
 # The suffix of source filenames.
 source_suffix = [".rst", ".md"]
-
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
Run build_tool_calling_documentation as a separate pre-processing step instead of running it within conf.py