### PR TITLE
Add permission filtering for tools

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.1.0
+- Filter llm tools by user permissions
+
 ## v2.0.2
 - Add Client.tickers() method for ticker industry filters for ISRCS and GICS
 

--- a/kfinance/constants.py
+++ b/kfinance/constants.py
@@ -88,6 +88,16 @@ class BusinessRelationshipType(StrEnum):
     client_services = "client_services"
 
 
+class Permission(Enum):
+    EarningsPermission = "EarningsPermission"
+    GICSPermission = "GICSPermission"
+    IDPermission = "IDPermission"
+    ISCRSPermission = "ISCRSPermission"
+    PricingPermission = "PricingPermission"
+    RelationshipPermission = "RelationshipPermission"
+    StatementsPermission = "StatementsPermission"
+
+
 class YearAndQuarter(TypedDict):
     year: int
     quarter: int

--- a/kfinance/fetch.py
+++ b/kfinance/fetch.py
@@ -1,5 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+import logging
 from time import time
 from typing import Callable, Generator, Optional
 from uuid import uuid4
@@ -13,6 +14,7 @@ from .constants import (
     IndustryClassification,
     Periodicity,
     PeriodType,
+    Permission,
 )
 
 
@@ -22,6 +24,8 @@ try:
     from .version import __version__ as kfinance_version
 except ImportError:
     kfinance_version = "dev"
+
+logger = logging.getLogger(__name__)
 
 
 DEFAULT_API_HOST: str = "https://kfinance.kensho.com"
@@ -86,6 +90,7 @@ class KFinanceApiClient:
         self.user_agent_source = "object_oriented"
         self._batch_id: str | None = None
         self._batch_size: str | None = None
+        self._user_permissions: set[Permission] | None = None
 
     @contextmanager
     def batch_request_header(self, batch_size: int) -> Generator:
@@ -127,6 +132,9 @@ class KFinanceApiClient:
                 # nosemgrep:  python.jwt.security.unverified-jwt-decode.unverified-jwt-decode
                 options={"verify_signature": False},
             ).get("exp")
+            # When the access token gets refreshed, also refresh user permissions in case they
+            # have been updated.
+            self._refresh_user_permissions()
         return self._access_token
 
     def _get_access_token_via_refresh_token(self) -> str:
@@ -168,6 +176,33 @@ class KFinanceApiClient:
         )
         response.raise_for_status()
         return response.json().get("access_token")
+
+    @property
+    def user_permissions(self) -> set[Permission]:
+        """Return the permissions that the current user holds."""
+
+        if self._user_permissions is None:
+            self._refresh_user_permissions()
+            # _refresh_user_permissions updates self._user_permissions in place
+            assert self._user_permissions is not None
+        return self._user_permissions
+
+    def _refresh_user_permissions(self) -> None:
+        """Fetches user permissions and stores them as KfinanceApiClient._user_permissions."""
+
+        user_permission_dict = self.fetch_permissions()
+        self._user_permissions = set()
+        for permission_str in user_permission_dict["permissions"]:
+            try:
+                self._user_permissions.add(Permission[permission_str])
+            except KeyError:
+                logger.warning(
+                    "Could not resolve %s to a member of the Permission enum. "
+                    "%s may be a new type of permission that still needs to be "
+                    "added to the enum.",
+                    permission_str,
+                    permission_str,
+                )
 
     def fetch(self, url: str) -> dict:
         """Does the request and auth"""

--- a/kfinance/fetch.py
+++ b/kfinance/fetch.py
@@ -191,6 +191,11 @@ class KFinanceApiClient:
         response.raise_for_status()
         return response.json()
 
+    def fetch_permissions(self) -> dict[str, list[str]]:
+        """Return the permissions of the user."""
+        url = f"{self.url_base}users/permissions"
+        return self.fetch(url)
+
     def fetch_id_triple(self, identifier: str, exchange_code: Optional[str] = None) -> dict:
         """Get the ID triple from [identifier]."""
         url = f"{self.url_base}id/{identifier}"

--- a/kfinance/kfinance.py
+++ b/kfinance/kfinance.py
@@ -25,7 +25,6 @@ from .constants import (
     IndustryClassification,
     LatestPeriods,
     Periodicity,
-    Permission,
     YearAndQuarter,
 )
 from .fetch import (
@@ -1158,28 +1157,6 @@ class Client:
             stdout.write("Login credentials received.\n")
 
         self._tools: list[KfinanceTool] | None = None
-        self._user_permissions: set[Permission] | None = None
-
-    @property
-    def user_permissions(self) -> set[Permission]:
-        """Return the permissions that the current user holds."""
-
-        if self._user_permissions is None:
-            # Fetch and parse user permissions
-            user_permission_dict = self.kfinance_api_client.fetch_permissions()
-            self._user_permissions = set()
-            for permission_str in user_permission_dict["permissions"]:
-                try:
-                    self._user_permissions.add(Permission[permission_str])
-                except KeyError:
-                    logger.warning(
-                        "Could not resolve %s to a member of the Permission enum. "
-                        "%s may be a new type of permission that still needs to be "
-                        "added to the enum.",
-                        permission_str,
-                        permission_str,
-                    )
-        return self._user_permissions
 
     @property
     def langchain_tools(self) -> list["KfinanceTool"]:
@@ -1193,7 +1170,7 @@ class Client:
                 tool = tool_cls(kfinance_client=self)  # type: ignore[call-arg]
                 if (
                     tool.required_permission is None
-                    or tool.required_permission in self.user_permissions
+                    or tool.required_permission in self.kfinance_api_client.user_permissions
                 ):
                     self._tools.append(tool)
 

--- a/kfinance/tests/test_client.py
+++ b/kfinance/tests/test_client.py
@@ -1,0 +1,54 @@
+from unittest.mock import Mock
+
+import pytest
+
+from kfinance.constants import Permission
+from kfinance.kfinance import Client
+from kfinance.tool_calling import (
+    GetBusinessRelationshipFromIdentifier,
+    GetFinancialStatementFromIdentifier,
+    GetLatest,
+)
+
+
+class TestLangchainTools:
+    @pytest.mark.parametrize(
+        "fetch_value, parsed_permissions",
+        [
+            pytest.param(["RelationshipPermission"], {Permission.RelationshipPermission}),
+            pytest.param([], set(), id="empty permissions don't raise."),
+            pytest.param(
+                ["InvalidPermission"], set(), id="invalid permissions get logged but don't raise."
+            ),
+        ],
+    )
+    def test_user_permissions(
+        self, fetch_value: list[str], parsed_permissions: set[Permission], mock_client: Client
+    ) -> None:
+        """
+        WHEN we fetch user permissions from the fetch_permissions endpoint
+        THEN we correctly parse those permission strings into Permission enums.
+        """
+        mock_client.kfinance_api_client.fetch_permissions = Mock()
+        mock_client.kfinance_api_client.fetch_permissions.return_value = {
+            "permissions": fetch_value
+        }
+
+        assert mock_client.user_permissions == parsed_permissions
+
+    def test_permission_filtering(self, mock_client: Client):
+        """
+        GIVEN a user with limited permissions
+        WHEN we filter tools by permissions
+        THEN we only return tools that either don't require permissions or tools that the user
+            specifically has access to.
+        """
+
+        mock_client._user_permissions = {Permission.RelationshipPermission}  # noqa: SLF001
+        tool_classes = [type(t) for t in mock_client.langchain_tools]
+        # User should have access to GetBusinessRelationshipFromIdentifier
+        assert GetBusinessRelationshipFromIdentifier in tool_classes
+        # User should have access to functions that don't require permissions
+        assert GetLatest in tool_classes
+        # User should not have access to functions that require statement permissions
+        assert GetFinancialStatementFromIdentifier not in tool_classes

--- a/kfinance/tests/test_client.py
+++ b/kfinance/tests/test_client.py
@@ -34,7 +34,7 @@ class TestLangchainTools:
             "permissions": fetch_value
         }
 
-        assert mock_client.user_permissions == parsed_permissions
+        assert mock_client.kfinance_api_client.user_permissions == parsed_permissions
 
     def test_permission_filtering(self, mock_client: Client):
         """
@@ -44,7 +44,7 @@ class TestLangchainTools:
             specifically has access to.
         """
 
-        mock_client._user_permissions = {Permission.RelationshipPermission}  # noqa: SLF001
+        mock_client.kfinance_api_client._user_permissions = {Permission.RelationshipPermission}  # noqa: SLF001
         tool_classes = [type(t) for t in mock_client.langchain_tools]
         # User should have access to GetBusinessRelationshipFromIdentifier
         assert GetBusinessRelationshipFromIdentifier in tool_classes

--- a/kfinance/tests/test_fetch.py
+++ b/kfinance/tests/test_fetch.py
@@ -250,3 +250,9 @@ class TestMarketCap:
             company_id=company_id, start_date=start_date, end_date=end_date
         )
         client.fetch.assert_called_with(expected_fetch_url)
+
+    def test_fetch_permissions(self):
+        client = build_mock_api_client()
+        expected_fetch_url = f"{client.url_base}users/permissions"
+        client.fetch_permissions()
+        client.fetch.assert_called_with(expected_fetch_url)

--- a/kfinance/tests/test_tools.py
+++ b/kfinance/tests/test_tools.py
@@ -1,7 +1,6 @@
 from datetime import date, datetime
 
 from langchain_core.utils.function_calling import convert_to_openai_tool
-import pytest
 from requests_mock import Mocker
 import time_machine
 
@@ -42,27 +41,6 @@ from kfinance.tool_calling.get_latest import GetLatestArgs
 from kfinance.tool_calling.get_n_quarters_ago import GetNQuartersAgoArgs
 from kfinance.tool_calling.get_prices_from_identifier import GetPricesFromIdentifierArgs
 from kfinance.tool_calling.shared_models import ToolArgsWithIdentifier
-
-
-@pytest.fixture
-def mock_client(requests_mock: Mocker) -> Client:
-    """Create a KFinanceApiClient with a mock response for the SPGI id triple."""
-
-    client = Client(refresh_token="foo")
-    # Set access token so that the client doesn't try to fetch it.
-    client.kfinance_api_client._access_token = "foo"  # noqa: SLF001
-    client.kfinance_api_client._access_token_expiry = datetime(2100, 1, 1).timestamp()  # noqa: SLF001
-
-    # Create a mock for the SPGI id triple.
-    requests_mock.get(
-        url="https://kfinance.kensho.com/api/v1/id/SPGI",
-        json={
-            "trading_item_id": SPGI_TRADING_ITEM_ID,
-            "security_id": SPGI_SECURITY_ID,
-            "company_id": SPGI_COMPANY_ID,
-        },
-    )
-    return client
 
 
 class TestGetBusinessRelationshipFromIdentifier:

--- a/kfinance/tool_calling/get_business_relationship_from_identifier.py
+++ b/kfinance/tool_calling/get_business_relationship_from_identifier.py
@@ -2,7 +2,7 @@ from typing import Type
 
 from pydantic import BaseModel
 
-from kfinance.constants import BusinessRelationshipType
+from kfinance.constants import BusinessRelationshipType, Permission
 from kfinance.kfinance import BusinessRelationships
 from kfinance.tool_calling.shared_models import KfinanceTool, ToolArgsWithIdentifier
 
@@ -16,6 +16,7 @@ class GetBusinessRelationshipFromIdentifier(KfinanceTool):
     name: str = "get_business_relationship_from_identifier"
     description: str = 'Get the current and previous company IDs that are relationship_type of a given identifier. For example, "What are the current distributors of SPGI?" or "What are the previous borrowers of JPM?"'
     args_schema: Type[BaseModel] = GetBusinessRelationshipFromIdentifierArgs
+    required_permission: Permission | None = Permission.RelationshipPermission
 
     def _run(self, identifier: str, business_relationship: BusinessRelationshipType) -> dict:
         ticker = self.kfinance_client.ticker(identifier)

--- a/kfinance/tool_calling/get_capitalization_from_identifier.py
+++ b/kfinance/tool_calling/get_capitalization_from_identifier.py
@@ -2,7 +2,7 @@ from datetime import date
 
 from pydantic import Field
 
-from kfinance.constants import Capitalization
+from kfinance.constants import Capitalization, Permission
 from kfinance.tool_calling.shared_models import KfinanceTool, ToolArgsWithIdentifier
 
 
@@ -21,6 +21,7 @@ class GetCapitalizationFromIdentifier(KfinanceTool):
     name: str = "get_capitalization_from_identifier"
     description: str = "Get the historical market cap, tev (Total Enterprise Value), or shares outstanding of an identifier between inclusive start_date and inclusive end date. When requesting the most recent values, leave start_date and end_date empty."
     args_schema = GetCapitalizationFromIdentifierArgs
+    required_permission: Permission | None = Permission.PricingPermission
 
     def _run(
         self,

--- a/kfinance/tool_calling/get_company_id_from_identifier.py
+++ b/kfinance/tool_calling/get_company_id_from_identifier.py
@@ -2,6 +2,7 @@ from typing import Type
 
 from pydantic import BaseModel
 
+from kfinance.constants import Permission
 from kfinance.tool_calling.shared_models import KfinanceTool, ToolArgsWithIdentifier
 
 
@@ -9,6 +10,7 @@ class GetCompanyIdFromIdentifier(KfinanceTool):
     name: str = "get_company_id_from_identifier"
     description: str = "Get the company id associated with an identifier."
     args_schema: Type[BaseModel] = ToolArgsWithIdentifier
+    required_permission: Permission | None = None
 
     def _run(self, identifier: str) -> int:
         return self.kfinance_client.ticker(identifier).company_id

--- a/kfinance/tool_calling/get_cusip_from_ticker.py
+++ b/kfinance/tool_calling/get_cusip_from_ticker.py
@@ -2,6 +2,7 @@ from typing import Type
 
 from pydantic import BaseModel, Field
 
+from kfinance.constants import Permission
 from kfinance.tool_calling.shared_models import KfinanceTool
 
 
@@ -13,6 +14,7 @@ class GetCusipFromTicker(KfinanceTool):
     name: str = "get_cusip_from_ticker"
     description: str = "Get the CUSIP associated with a ticker."
     args_schema: Type[BaseModel] = GetCusipFromTickerArgs
+    required_permission: Permission | None = Permission.IDPermission
 
     def _run(self, ticker_str: str) -> str:
         return self.kfinance_client.ticker(ticker_str).cusip

--- a/kfinance/tool_calling/get_earnings_call_datetimes_from_identifier.py
+++ b/kfinance/tool_calling/get_earnings_call_datetimes_from_identifier.py
@@ -3,6 +3,7 @@ from typing import Type
 
 from pydantic import BaseModel
 
+from kfinance.constants import Permission
 from kfinance.tool_calling.shared_models import KfinanceTool, ToolArgsWithIdentifier
 
 
@@ -10,6 +11,7 @@ class GetEarningsCallDatetimesFromIdentifier(KfinanceTool):
     name: str = "get_earnings_call_datetimes_from_identifier"
     description: str = "Get earnings call datetimes associated with an identifier."
     args_schema: Type[BaseModel] = ToolArgsWithIdentifier
+    required_permission: Permission | None = Permission.EarningsPermission
 
     def _run(self, identifier: str) -> str:
         ticker = self.kfinance_client.ticker(identifier)

--- a/kfinance/tool_calling/get_financial_line_item_from_identifier.py
+++ b/kfinance/tool_calling/get_financial_line_item_from_identifier.py
@@ -2,7 +2,7 @@ from typing import Literal, Type
 
 from pydantic import BaseModel, Field
 
-from kfinance.constants import LINE_ITEM_NAMES_AND_ALIASES, PeriodType
+from kfinance.constants import LINE_ITEM_NAMES_AND_ALIASES, PeriodType, Permission
 from kfinance.tool_calling.shared_models import KfinanceTool, ToolArgsWithIdentifier
 
 
@@ -24,6 +24,7 @@ class GetFinancialLineItemFromIdentifier(KfinanceTool):
     name: str = "get_financial_line_item_from_identifier"
     description: str = "Get the financial line item associated with an identifier."
     args_schema: Type[BaseModel] = GetFinancialLineItemFromIdentifierArgs
+    required_permission: Permission | None = Permission.StatementsPermission
 
     def _run(
         self,

--- a/kfinance/tool_calling/get_financial_statement_from_identifier.py
+++ b/kfinance/tool_calling/get_financial_statement_from_identifier.py
@@ -2,7 +2,7 @@ from typing import Literal, Type
 
 from pydantic import BaseModel, Field
 
-from kfinance.constants import PeriodType, StatementType
+from kfinance.constants import PeriodType, Permission, StatementType
 from kfinance.tool_calling.shared_models import KfinanceTool, ToolArgsWithIdentifier
 
 
@@ -20,6 +20,7 @@ class GetFinancialStatementFromIdentifier(KfinanceTool):
     name: str = "get_financial_statement_from_identifier"
     description: str = "Get the financial statement associated with an identifier."
     args_schema: Type[BaseModel] = GetFinancialStatementFromIdentifierArgs
+    required_permission: Permission | None = Permission.StatementsPermission
 
     def _run(
         self,

--- a/kfinance/tool_calling/get_history_metadata_from_identifier.py
+++ b/kfinance/tool_calling/get_history_metadata_from_identifier.py
@@ -2,7 +2,7 @@ from typing import Type
 
 from pydantic import BaseModel
 
-from kfinance.constants import HistoryMetadata
+from kfinance.constants import HistoryMetadata, Permission
 from kfinance.tool_calling.shared_models import KfinanceTool, ToolArgsWithIdentifier
 
 
@@ -10,6 +10,7 @@ class GetHistoryMetadataFromIdentifier(KfinanceTool):
     name: str = "get_history_metadata_from_identifier"
     description: str = "Get the history metadata associated with an identifier. History metadata includes currency, symbol, exchange name, instrument type, and first trade date."
     args_schema: Type[BaseModel] = ToolArgsWithIdentifier
+    required_permission: Permission | None = None
 
     def _run(self, identifier: str) -> HistoryMetadata:
         return self.kfinance_client.ticker(identifier).history_metadata

--- a/kfinance/tool_calling/get_info_from_identifier.py
+++ b/kfinance/tool_calling/get_info_from_identifier.py
@@ -2,6 +2,7 @@ from typing import Type
 
 from pydantic import BaseModel
 
+from kfinance.constants import Permission
 from kfinance.tool_calling.shared_models import KfinanceTool, ToolArgsWithIdentifier
 
 
@@ -9,6 +10,7 @@ class GetInfoFromIdentifier(KfinanceTool):
     name: str = "get_info_from_identifier"
     description: str = "Get the information associated with an identifier. Info includes company name, status, type, simple industry, number of employees, founding date, webpage, HQ address, HQ city, HQ zip code, HQ state, HQ country, and HQ country iso code."
     args_schema: Type[BaseModel] = ToolArgsWithIdentifier
+    required_permission: Permission | None = None
 
     def _run(self, identifier: str) -> str:
         return str(self.kfinance_client.ticker(identifier).info)

--- a/kfinance/tool_calling/get_isin_from_ticker.py
+++ b/kfinance/tool_calling/get_isin_from_ticker.py
@@ -2,6 +2,7 @@ from typing import Type
 
 from pydantic import BaseModel, Field
 
+from kfinance.constants import Permission
 from kfinance.tool_calling.shared_models import KfinanceTool
 
 
@@ -13,6 +14,7 @@ class GetIsinFromTicker(KfinanceTool):
     name: str = "get_isin_from_ticker"
     description: str = "Get the ISIN associated with a ticker."
     args_schema: Type[BaseModel] = GetIsinFromTickerArgs
+    required_permission: Permission | None = Permission.IDPermission
 
     def _run(self, ticker_str: str) -> str:
         return self.kfinance_client.ticker(ticker_str).isin

--- a/kfinance/tool_calling/get_latest.py
+++ b/kfinance/tool_calling/get_latest.py
@@ -2,7 +2,7 @@ from typing import Type
 
 from pydantic import BaseModel, Field
 
-from kfinance.constants import LatestPeriods
+from kfinance.constants import LatestPeriods, Permission
 from kfinance.tool_calling.shared_models import KfinanceTool
 
 
@@ -16,6 +16,7 @@ class GetLatest(KfinanceTool):
     name: str = "get_latest"
     description: str = "Get the latest annual reporting year, latest quarterly reporting quarter and year, and current date."
     args_schema: Type[BaseModel] = GetLatestArgs
+    required_permission: Permission | None = None
 
     def _run(self, use_local_timezone: bool = True) -> LatestPeriods:
         return self.kfinance_client.get_latest(use_local_timezone=use_local_timezone)

--- a/kfinance/tool_calling/get_n_quarters_ago.py
+++ b/kfinance/tool_calling/get_n_quarters_ago.py
@@ -2,7 +2,7 @@ from typing import Type
 
 from pydantic import BaseModel, Field
 
-from kfinance.constants import YearAndQuarter
+from kfinance.constants import Permission, YearAndQuarter
 from kfinance.tool_calling.shared_models import KfinanceTool
 
 
@@ -16,6 +16,7 @@ class GetNQuartersAgo(KfinanceTool):
         "Get the year and quarter corresponding to [n] quarters before the current quarter."
     )
     args_schema: Type[BaseModel] = GetNQuartersAgoArgs
+    required_permission: Permission | None = None
 
     def _run(self, n: int) -> YearAndQuarter:
         return self.kfinance_client.get_n_quarters_ago(n)

--- a/kfinance/tool_calling/get_prices_from_identifier.py
+++ b/kfinance/tool_calling/get_prices_from_identifier.py
@@ -3,7 +3,7 @@ from typing import Type
 
 from pydantic import BaseModel, Field
 
-from kfinance.constants import Periodicity
+from kfinance.constants import Periodicity, Permission
 from kfinance.tool_calling.shared_models import KfinanceTool, ToolArgsWithIdentifier
 
 
@@ -26,6 +26,7 @@ class GetPricesFromIdentifier(KfinanceTool):
     name: str = "get_prices_from_identifier"
     description: str = "Get the historical open, high, low, and close prices, and volume of an identifier between inclusive start_date and inclusive end date. When requesting the most recent values, leave start_date and end_date empty."
     args_schema: Type[BaseModel] = GetPricesFromIdentifierArgs
+    required_permission: Permission | None = Permission.PricingPermission
 
     def _run(
         self,

--- a/kfinance/tool_calling/get_security_id_from_identifier.py
+++ b/kfinance/tool_calling/get_security_id_from_identifier.py
@@ -2,6 +2,7 @@ from typing import Type
 
 from pydantic import BaseModel
 
+from kfinance.constants import Permission
 from kfinance.tool_calling.shared_models import KfinanceTool, ToolArgsWithIdentifier
 
 
@@ -9,6 +10,7 @@ class GetSecurityIdFromIdentifier(KfinanceTool):
     name: str = "get_security_id_from_identifier"
     description: str = "Get the security id associated with an identifier."
     args_schema: Type[BaseModel] = ToolArgsWithIdentifier
+    required_permission: Permission | None = None
 
     def _run(self, identifier: str) -> int:
         return self.kfinance_client.ticker(identifier).security_id

--- a/kfinance/tool_calling/get_trading_item_id_from_identifier.py
+++ b/kfinance/tool_calling/get_trading_item_id_from_identifier.py
@@ -2,6 +2,7 @@ from typing import Type
 
 from pydantic import BaseModel
 
+from kfinance.constants import Permission
 from kfinance.tool_calling.shared_models import KfinanceTool, ToolArgsWithIdentifier
 
 
@@ -9,6 +10,7 @@ class GetTradingItemIdFromIdentifier(KfinanceTool):
     name: str = "get_trading_item_id_from_identifier"
     description: str = "Get the trading item id associated with an identifier."
     args_schema: Type[BaseModel] = ToolArgsWithIdentifier
+    required_permission: Permission | None = None
 
     def _run(self, identifier: str) -> int:
         return self.kfinance_client.ticker(identifier).trading_item_id

--- a/kfinance/tool_calling/shared_models.py
+++ b/kfinance/tool_calling/shared_models.py
@@ -3,6 +3,7 @@ from typing import Any, Type
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, ConfigDict, Field
 
+from kfinance.constants import Permission
 from kfinance.kfinance import Client
 
 
@@ -15,6 +16,7 @@ class KfinanceTool(BaseTool):
 
     kfinance_client: Client
     args_schema: Type[BaseModel]
+    required_permission: Permission | None
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 


### PR DESCRIPTION
Only include tools that the user has access to for llm tools. 
There is no point including tools that the user does not have access to as they would just return 403s.

This PR is ready for reviews. I set to draft until the permission endpoint becomes available in hydra on 4/30.