### PR TITLE
Use cachetools cache

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.1.1
+- Use cachetools cache
+
 ## v2.1.0
 - Filter llm tools by user permissions
 

--- a/kfinance/constants.py
+++ b/kfinance/constants.py
@@ -27,7 +27,7 @@ class IdentificationTriple(NamedTuple):
     company_id: int
 
 
-class Capitalization(Enum):
+class Capitalization(StrEnum):
     """The capitalization type"""
 
     market_cap = "market_cap"
@@ -35,7 +35,7 @@ class Capitalization(Enum):
     shares_outstanding = "shares_outstanding"
 
 
-class PeriodType(Enum):
+class PeriodType(StrEnum):
     """The period type"""
 
     annual = "annual"
@@ -44,7 +44,7 @@ class PeriodType(Enum):
     ytd = "ytd"
 
 
-class Periodicity(Enum):
+class Periodicity(StrEnum):
     """The frequency or interval at which the historical data points are sampled or aggregated. Periodicity is not the same as the date range. The date range specifies the time span over which the data is retrieved, while periodicity determines how the data within that date range is aggregated."""
 
     day = "day"
@@ -53,7 +53,7 @@ class Periodicity(Enum):
     year = "year"
 
 
-class StatementType(Enum):
+class StatementType(StrEnum):
     """The type of financial statement"""
 
     balance_sheet = "balance_sheet"
@@ -88,7 +88,7 @@ class BusinessRelationshipType(StrEnum):
     client_services = "client_services"
 
 
-class Permission(Enum):
+class Permission(StrEnum):
     EarningsPermission = "EarningsPermission"
     GICSPermission = "GICSPermission"
     IDPermission = "IDPermission"

--- a/kfinance/constants.py
+++ b/kfinance/constants.py
@@ -1,5 +1,4 @@
 from datetime import date
-from enum import Enum
 from itertools import chain
 from typing import NamedTuple, TypedDict
 

--- a/kfinance/fetch.py
+++ b/kfinance/fetch.py
@@ -281,7 +281,7 @@ class KFinanceApiClient:
             f"{self.url_base}pricing/{trading_item_id}/"
             f"{start_date if start_date is not None else 'none'}/"
             f"{end_date if end_date is not None else 'none'}/"
-            f"{periodicity.value if periodicity else 'none'}/"
+            f"{periodicity if periodicity else 'none'}/"
             f"{'adjusted' if is_adjusted else 'unadjusted'}"
         )
         return self.fetch(url)
@@ -318,7 +318,7 @@ class KFinanceApiClient:
             f"{self.url_base}price_chart/{trading_item_id}/"
             f"{start_date if start_date is not None else 'none'}/"
             f"{end_date if end_date is not None else 'none'}/"
-            f"{periodicity.value if periodicity else 'none'}/"
+            f"{periodicity if periodicity else 'none'}/"
             f"{'adjusted' if is_adjusted else 'unadjusted'}"
         )
 
@@ -346,7 +346,7 @@ class KFinanceApiClient:
         """Get a specified financial statement for a specified duration."""
         url = (
             f"{self.url_base}statements/{company_id}/{statement_type}/"
-            f"{period_type.value if period_type else 'none'}/"
+            f"{period_type if period_type else 'none'}/"
             f"{start_year if start_year is not None else 'none'}/"
             f"{end_year if end_year is not None else 'none'}/"
             f"{start_quarter if start_quarter is not None else 'none'}/"
@@ -367,7 +367,7 @@ class KFinanceApiClient:
         """Get a specified financial line item for a specified duration."""
         url = (
             f"{self.url_base}line_item/{company_id}/{line_item}/"
-            f"{period_type.value if period_type else 'none'}/"
+            f"{period_type if period_type else 'none'}/"
             f"{start_year if start_year is not None else 'none'}/"
             f"{end_year if end_year is not None else 'none'}/"
             f"{start_quarter if start_quarter is not None else 'none'}/"

--- a/kfinance/meta_classes.py
+++ b/kfinance/meta_classes.py
@@ -1,8 +1,9 @@
 from datetime import datetime
-from functools import cache, cached_property
+from functools import cached_property
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional
 
+from cachetools import LRUCache, cached
 import numpy as np
 import pandas as pd
 
@@ -46,7 +47,7 @@ class CompanyFunctionsMetaClass:
         if end_quarter and not (1 <= end_quarter <= 4):
             raise ValueError("end_qtr is out of range 1 to 4")
 
-    @cache
+    @cached(cache=LRUCache(maxsize=100))
     def statement(
         self,
         statement_type: str,
@@ -85,7 +86,7 @@ class CompanyFunctionsMetaClass:
 
     def income_statement(
         self,
-        period_type: Optional[str] = None,
+        period_type: Optional[PeriodType] = None,
         start_year: Optional[int] = None,
         end_year: Optional[int] = None,
         start_quarter: Optional[int] = None,
@@ -103,7 +104,7 @@ class CompanyFunctionsMetaClass:
 
     def income_stmt(
         self,
-        period_type: Optional[str] = None,
+        period_type: Optional[PeriodType] = None,
         start_year: Optional[int] = None,
         end_year: Optional[int] = None,
         start_quarter: Optional[int] = None,
@@ -121,7 +122,7 @@ class CompanyFunctionsMetaClass:
 
     def balance_sheet(
         self,
-        period_type: Optional[str] = None,
+        period_type: Optional[PeriodType] = None,
         start_year: Optional[int] = None,
         end_year: Optional[int] = None,
         start_quarter: Optional[int] = None,
@@ -139,7 +140,7 @@ class CompanyFunctionsMetaClass:
 
     def cash_flow(
         self,
-        period_type: Optional[str] = None,
+        period_type: Optional[PeriodType] = None,
         start_year: Optional[int] = None,
         end_year: Optional[int] = None,
         start_quarter: Optional[int] = None,
@@ -157,7 +158,7 @@ class CompanyFunctionsMetaClass:
 
     def cashflow(
         self,
-        period_type: Optional[str] = None,
+        period_type: Optional[PeriodType] = None,
         start_year: Optional[int] = None,
         end_year: Optional[int] = None,
         start_quarter: Optional[int] = None,
@@ -173,7 +174,7 @@ class CompanyFunctionsMetaClass:
             end_quarter=end_quarter,
         )
 
-    @cache
+    @cached(cache=LRUCache(maxsize=100))
     def line_item(
         self,
         line_item: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 
 
 dependencies = [
+    "cachetools>=5.5,<6",
     "langchain-core>=0.3.15",
     "langchain-google-genai>=2.1.0,<3",
     "numpy>=1.22.4",
@@ -41,7 +42,8 @@ dev = [
     "pytest-cov>=6.0.0,<7",
     "requests_mock>=1.12,<2",
     "ruff>=0.9.4,<1",
-    "time_machine>=2.1,<3"
+    "time_machine>=2.1,<3",
+    "types-cachetools>=5.5,<6"
 ]
 
 


### PR DESCRIPTION
functools `@cache` and `@lru_cache` are not yet properly typed and can mask typing errors. 

This PR replaces our `@cache` uses with equivalents from cachetools. 

Also replaces `Enum` with `StrEnum` to avoid `.value` calls. 


Tested:
```
kfinance_client = Client()
spgi = kfinance_client.ticker("SPGI")
spgi.balance_sheet(period_type="quarterly", start_year=2021, end_year=2022)
```
Not technically correct for mypy but works without errors.