### PR TITLE
Allow multiple batch requests to run in a single executor

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.1.2
+- Allow batch executor to handle multiple requests
+
 ## v2.1.1
 - Use cachetools cache
 

--- a/kfinance/batch_request_handling.py
+++ b/kfinance/batch_request_handling.py
@@ -72,19 +72,19 @@ def add_methods_of_singular_class_to_iterable_class(singular_cls: Type[T]) -> Ca
         def process_in_batch(
             method: Callable, self: IterableKfinanceClass, *args: Any, **kwargs: Any
         ) -> dict:
-            results = {}
             kfinance_api_client = self.kfinance_api_client
             with kfinance_api_client.batch_request_header(batch_size=len(self)):
-                with kfinance_api_client.thread_pool as executor:
-                    results = dict(
-                        zip(
-                            self,
-                            [
-                                process_in_thread_pool(executor, method, obj, *args, **kwargs)
-                                for obj in self
-                            ],
-                        )
+                results = dict(
+                    zip(
+                        self,
+                        [
+                            process_in_thread_pool(
+                                kfinance_api_client.thread_pool, method, obj, *args, **kwargs
+                            )
+                            for obj in self
+                        ],
                     )
+                )
 
             return results
 

--- a/kfinance/kfinance.py
+++ b/kfinance/kfinance.py
@@ -234,10 +234,9 @@ class Company(CompanyFunctionsMetaClass):
         primary_security_id = self.kfinance_api_client.fetch_primary_security(self.company_id)[
             "primary_security"
         ]
-        self.primary_security = Security(
+        return Security(
             kfinance_api_client=self.kfinance_api_client, security_id=primary_security_id
         )
-        return self.primary_security
 
     @cached_property
     def securities(self) -> Securities:
@@ -247,10 +246,7 @@ class Company(CompanyFunctionsMetaClass):
         :rtype: Securities
         """
         security_ids = self.kfinance_api_client.fetch_securities(self.company_id)["securities"]
-        self.securities = Securities(
-            kfinance_api_client=self.kfinance_api_client, security_ids=security_ids
-        )
-        return self.securities
+        return Securities(kfinance_api_client=self.kfinance_api_client, security_ids=security_ids)
 
     @cached_property
     def latest_earnings_call(self) -> None:
@@ -269,8 +265,7 @@ class Company(CompanyFunctionsMetaClass):
         :return: a dict with containing: name, status, type, simple industry, number of employees, founding date, webpage, address, city, zip code, state, country, & iso_country
         :rtype: dict
         """
-        self.info = self.kfinance_api_client.fetch_info(self.company_id)
-        return self.info
+        return self.kfinance_api_client.fetch_info(self.company_id)
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
So far, only a single batch request could be submitted to a client because the executor shut down at the end of the `with threadpoolexecutor as e` block.

For more discussion, see https://onekensho.slack.com/archives/C07GN0HHCMD/p1747085057979139?thread_ts=1744058992.239649&cid=C07GN0HHCMD