### PR TITLE
Make employee number optional

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.2.1
+- Make number of employees optional to reflect backend changes
+
 ## v2.2.0
 - Replace get company id, get security id, get trading item id tools with resolve identifier tool
 

--- a/kfinance/kfinance.py
+++ b/kfinance/kfinance.py
@@ -262,7 +262,7 @@ class Company(CompanyFunctionsMetaClass):
     def info(self) -> dict:
         """Get the company info
 
-        :return: a dict with containing: name, status, type, simple industry, number of employees, founding date, webpage, address, city, zip code, state, country, & iso_country
+        :return: a dict with containing: name, status, type, simple industry, number of employees (if available), founding date, webpage, address, city, zip code, state, country, & iso_country
         :rtype: dict
         """
         return self.kfinance_api_client.fetch_info(self.company_id)
@@ -304,11 +304,11 @@ class Company(CompanyFunctionsMetaClass):
         return self.info["simple_industry"]
 
     @property
-    def number_of_employees(self) -> str:
-        """Get the number of employees the company has
+    def number_of_employees(self) -> str | None:
+        """Get the number of employees the company has (if available)
 
         :return: how many employees the company has
-        :rtype: str
+        :rtype: str | None
         """
         return self.info["number_of_employees"]
 
@@ -685,7 +685,7 @@ class Ticker(DelegatedCompanyFunctionsMetaClass):
     def info(self) -> dict:
         """Get the company info for the ticker
 
-        :return: a dict with containing: name, status, type, simple industry, number of employees, founding date, webpage, address, city, zip code, state, country, & iso_country
+        :return: a dict with containing: name, status, type, simple industry, number of employees (if available), founding date, webpage, address, city, zip code, state, country, & iso_country
         :rtype: dict
         """
         return self.company.info
@@ -727,11 +727,11 @@ class Ticker(DelegatedCompanyFunctionsMetaClass):
         return self.company.simple_industry
 
     @property
-    def number_of_employees(self) -> str:
-        """Get the number of employees the company has
+    def number_of_employees(self) -> str | None:
+        """Get the number of employees the company has (if available)
 
         :return: how many employees the company has
-        :rtype: str
+        :rtype: str | None
         """
         return self.company.number_of_employees
 

--- a/kfinance/tool_calling/get_info_from_identifier.py
+++ b/kfinance/tool_calling/get_info_from_identifier.py
@@ -8,7 +8,7 @@ from kfinance.tool_calling.shared_models import KfinanceTool, ToolArgsWithIdenti
 
 class GetInfoFromIdentifier(KfinanceTool):
     name: str = "get_info_from_identifier"
-    description: str = "Get the information associated with an identifier. Info includes company name, status, type, simple industry, number of employees, founding date, webpage, HQ address, HQ city, HQ zip code, HQ state, HQ country, and HQ country iso code."
+    description: str = "Get the information associated with an identifier. Info includes company name, status, type, simple industry, number of employees (if available), founding date, webpage, HQ address, HQ city, HQ zip code, HQ state, HQ country, and HQ country iso code."
     args_schema: Type[BaseModel] = ToolArgsWithIdentifier
     required_permission: Permission | None = None
 


### PR DESCRIPTION
The number of employees is now optional on the backend (only returned if available).
This PR reflects that change in the client.