### PR TITLE
Remove cached properties

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
+## v2.3.1
+- Replace `cached_property` with `property` to enable batching
+
 ## v2.3.0
 - Add earnings and transcript objects
+
 
 ## v2.2.5
 - Add parsing for relationship response with name

--- a/kfinance/batch_request_handling.py
+++ b/kfinance/batch_request_handling.py
@@ -1,6 +1,5 @@
 from concurrent.futures import Future
 import functools
-from functools import cached_property
 import threading
 from typing import Any, Callable, Iterable, Protocol, Sized, Type, TypeVar
 
@@ -17,7 +16,7 @@ throttle = threading.Semaphore(MAX_WORKERS_CAP)
 
 
 def add_methods_of_singular_class_to_iterable_class(singular_cls: Type[T]) -> Callable:
-    """Returns a decorator that sets each method, property, and cached_property of"""
+    """Returns a decorator that adds methods and properties from a singular to a plural class."""
     "[singular_cls] as an attribute of the decorated class."
 
     class IterableKfinanceClass(Protocol, Sized, Iterable[T]):
@@ -32,7 +31,7 @@ def add_methods_of_singular_class_to_iterable_class(singular_cls: Type[T]) -> Ca
         """Adds functions from a singular class to an iterable class.
 
         This decorator modifies the [iterable_cls] so that when an attribute
-        (method, property, or cached property) added by the decorator is accessed,
+        (method or property) added by the decorator is accessed,
         it returns a dictionary. This dictionary maps each object in [iterable_cls]
         to the result of invoking the attribute on that specific object.
 
@@ -108,19 +107,6 @@ def add_methods_of_singular_class_to_iterable_class(singular_cls: Type[T]) -> Ca
                     return prop_wrapper
 
                 setattr(iterable_cls, method_name, property(create_prop_wrapper(method)))
-
-            elif isinstance(method, cached_property):
-
-                def create_cached_prop_wrapper(method: cached_property) -> cached_property:
-                    @functools.wraps(method.func)
-                    def cached_prop_wrapper(self: IterableKfinanceClass) -> Any:
-                        return process_in_batch(method.func, self)
-
-                    wrapped_cached_property = cached_property(cached_prop_wrapper)
-                    wrapped_cached_property.__set_name__(iterable_cls, method_name)
-                    return wrapped_cached_property
-
-                setattr(iterable_cls, method_name, create_cached_prop_wrapper(method))
 
         return iterable_cls
 

--- a/kfinance/kfinance.py
+++ b/kfinance/kfinance.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime, timezone
-from functools import cached_property
 from io import BytesIO
 import logging
 import re
@@ -79,8 +78,9 @@ class TradingItem:
         """
         self.kfinance_api_client = kfinance_api_client
         self.trading_item_id = trading_item_id
-        self.ticker: Optional[str] = None
-        self.exchange_code: Optional[str] = None
+
+        self._ticker: str | None = None
+        self._history_metadata: HistoryMetadata | None = None
 
     def __str__(self) -> str:
         """String representation for the company object"""
@@ -103,36 +103,35 @@ class TradingItem:
             "trading_item_id"
         ]
         trading_item = TradingItem(kfinance_api_client, trading_item_id)
-        trading_item.ticker = ticker
-        trading_item.exchange_code = exchange_code
+        trading_item._ticker = ticker
         return trading_item
 
-    @cached_property
-    def trading_item_id(self) -> int:
-        """Get the trading item id for the object
-
-        :return: the CIQ trading item id
-        :rtype: int
-        """
-        return self.trading_item_id
-
-    @cached_property
+    @property
     def history_metadata(self) -> HistoryMetadata:
         """Get information about exchange and quotation
 
         :return: A dict containing data about the currency, symbol, exchange, type of instrument, and the first trading date
         :rtype: HistoryMetadata
         """
-        metadata = self.kfinance_api_client.fetch_history_metadata(self.trading_item_id)
-        if self.exchange_code is None:
-            self.exchange_code = metadata["exchange_name"]
-        return {
-            "currency": metadata["currency"],
-            "symbol": metadata["symbol"],
-            "exchange_name": metadata["exchange_name"],
-            "instrument_type": metadata["instrument_type"],
-            "first_trade_date": datetime.strptime(metadata["first_trade_date"], "%Y-%m-%d").date(),
-        }
+        if self._history_metadata is None:
+            metadata = self.kfinance_api_client.fetch_history_metadata(self.trading_item_id)
+            self._history_metadata = HistoryMetadata(
+                currency=metadata["currency"],
+                symbol=metadata["symbol"],
+                exchange_name=metadata["exchange_name"],
+                instrument_type=metadata["instrument_type"],
+                first_trade_date=datetime.strptime(metadata["first_trade_date"], "%Y-%m-%d").date(),
+            )
+        return self._history_metadata
+
+    @property
+    def exchange_code(self) -> str:
+        """Return the exchange_code of the trading item
+
+        :return: The exchange code of the trading item.
+        :rtype: str
+        """
+        return self.history_metadata["exchange_name"]
 
     def history(
         self,
@@ -316,45 +315,67 @@ class Company(CompanyFunctionsMetaClass):
         """
         super().__init__()
         self.kfinance_api_client = kfinance_api_client
-        self.company_id = company_id
+        self._company_id = company_id
         self._all_earnings: list[Earnings] | None = None
+
+        self._securities: Securities | None = None
+        self._primary_security: Security | None = None
+        self._info: dict | None = None
+        self._earnings_call_datetimes: list[datetime] | None = None
+
+    @property
+    def company_id(self) -> int:
+        """Return the company_id of the company.
+
+        :return: the company_id of the company
+        :rtype: int
+        """
+        return self._company_id
 
     def __str__(self) -> str:
         """String representation for the company object"""
         return f"{type(self).__module__}.{type(self).__qualname__} of {self.company_id}"
 
-    @cached_property
+    @property
     def primary_security(self) -> Security:
         """Return the primary security item for the Company object
 
         :return: a Security object of the primary security of company_id
         :rtype: Security
         """
-        primary_security_id = self.kfinance_api_client.fetch_primary_security(self.company_id)[
-            "primary_security"
-        ]
-        return Security(
-            kfinance_api_client=self.kfinance_api_client, security_id=primary_security_id
-        )
+        if self._primary_security is None:
+            primary_security_id = self.kfinance_api_client.fetch_primary_security(self.company_id)[
+                "primary_security"
+            ]
+            self._primary_security = Security(
+                kfinance_api_client=self.kfinance_api_client, security_id=primary_security_id
+            )
+        return self._primary_security
 
-    @cached_property
+    @property
     def securities(self) -> Securities:
         """Return the security items for the Company object
 
         :return: a Securities object containing the list of securities of company_id
         :rtype: Securities
         """
-        security_ids = self.kfinance_api_client.fetch_securities(self.company_id)["securities"]
-        return Securities(kfinance_api_client=self.kfinance_api_client, security_ids=security_ids)
+        if self._securities is None:
+            security_ids = self.kfinance_api_client.fetch_securities(self.company_id)["securities"]
+            self._securities = Securities(
+                kfinance_api_client=self.kfinance_api_client, security_ids=security_ids
+            )
+        return self._securities
 
-    @cached_property
+    @property
     def info(self) -> dict:
         """Get the company info
 
         :return: a dict with containing: name, status, type, simple industry, number of employees (if available), founding date, webpage, address, city, zip code, state, country, & iso_country
         :rtype: dict
         """
-        return self.kfinance_api_client.fetch_info(self.company_id)
+        if self._info is None:
+            self._info = self.kfinance_api_client.fetch_info(self.company_id)
+        return self._info
 
     @property
     def name(self) -> str:
@@ -473,19 +494,21 @@ class Company(CompanyFunctionsMetaClass):
         """
         return self.info["iso_country"]
 
-    @cached_property
+    @property
     def earnings_call_datetimes(self) -> list[datetime]:
         """Get the datetimes of the companies earnings calls
 
         :return: a list of datetimes for the companies earnings calls
         :rtype: list[datetime]
         """
-        return [
-            datetime.fromisoformat(earnings_call).replace(tzinfo=timezone.utc)
-            for earnings_call in self.kfinance_api_client.fetch_earnings_dates(self.company_id)[
-                "earnings"
+        if self._earnings_call_datetimes is None:
+            self._earnings_call_datetimes = [
+                datetime.fromisoformat(earnings_call).replace(tzinfo=timezone.utc)
+                for earnings_call in self.kfinance_api_client.fetch_earnings_dates(self.company_id)[
+                    "earnings"
+                ]
             ]
-        ]
+        return self._earnings_call_datetimes
 
     @property
     def all_earnings(self) -> list[Earnings]:
@@ -624,57 +647,69 @@ class Security:
         self.kfinance_api_client = kfinance_api_client
         self.security_id = security_id
 
+        self._cusip: str | None = None
+        self._isin: str | None = None
+        self._primary_trading_item: TradingItem | None = None
+        self._trading_items: TradingItems | None = None
+
     def __str__(self) -> str:
         """String representation for the security object"""
         return f"{type(self).__module__}.{type(self).__qualname__} of {self.security_id}"
 
-    @cached_property
+    @property
     def isin(self) -> str:
         """Get the ISIN for the object
 
         :return: The ISIN
         :rtype: str
         """
-        return self.kfinance_api_client.fetch_isin(self.security_id)["isin"]
+        if self._isin is None:
+            self._isin = self.kfinance_api_client.fetch_isin(self.security_id)["isin"]
+        return self._isin
 
-    @cached_property
+    @property
     def cusip(self) -> str:
         """Get the CUSIP for the object
 
         :return: The CUSIP
         :rtype: str
         """
-        return self.kfinance_api_client.fetch_cusip(self.security_id)["cusip"]
+        if self._cusip is None:
+            self._cusip = self.kfinance_api_client.fetch_cusip(self.security_id)["cusip"]
+        return self._cusip
 
-    @cached_property
+    @property
     def primary_trading_item(self) -> TradingItem:
         """Return the primary trading item for the Security object
 
         :return: a TradingItem object of the primary trading item of security_id
         :rtype: TradingItem
         """
-        primary_trading_item_id = self.kfinance_api_client.fetch_primary_trading_item(
-            self.security_id
-        )["primary_trading_item"]
-        self.primary_trading_item = TradingItem(
-            kfinance_api_client=self.kfinance_api_client, trading_item_id=primary_trading_item_id
-        )
-        return self.primary_trading_item
+        if self._primary_trading_item is None:
+            primary_trading_item_id = self.kfinance_api_client.fetch_primary_trading_item(
+                self.security_id
+            )["primary_trading_item"]
+            self._primary_trading_item = TradingItem(
+                kfinance_api_client=self.kfinance_api_client,
+                trading_item_id=primary_trading_item_id,
+            )
+        return self._primary_trading_item
 
-    @cached_property
+    @property
     def trading_items(self) -> TradingItems:
         """Return the trading items for the Security object
 
         :return: a TradingItems object containing the list of trading items of security_id
         :rtype: TradingItems
         """
-        trading_item_ids = self.kfinance_api_client.fetch_trading_items(self.security_id)[
-            "trading_items"
-        ]
-        self.trading_items = TradingItems(
-            kfinance_api_client=self.kfinance_api_client, trading_item_ids=trading_item_ids
-        )
-        return self.trading_items
+        if self._trading_items is None:
+            trading_item_ids = self.kfinance_api_client.fetch_trading_items(self.security_id)[
+                "trading_items"
+            ]
+            self._trading_items = TradingItems(
+                kfinance_api_client=self.kfinance_api_client, trading_item_ids=trading_item_ids
+            )
+        return self._trading_items
 
 
 class Ticker(DelegatedCompanyFunctionsMetaClass):
@@ -735,6 +770,11 @@ class Ticker(DelegatedCompanyFunctionsMetaClass):
             raise RuntimeError(
                 "Neither an identifier nor an identification triple (company id, security id, & trading item id) were passed in"
             )
+
+        self._primary_security: Security | None = None
+        self._primary_trading_item: TradingItem | None = None
+        self._company: Company | None = None
+        self._history_metadata: HistoryMetadata | None = None
 
     @property
     def id_triple(self) -> IdentificationTriple:
@@ -819,44 +859,46 @@ class Ticker(DelegatedCompanyFunctionsMetaClass):
         """
         return self.id_triple.trading_item_id
 
-    @cached_property
+    @property
     def primary_security(self) -> Security:
         """Set and return the primary security for the object
 
         :return: The primary security as a Security object
         :rtype: Security
         """
+        if self._primary_security is None:
+            self._primary_security = Security(
+                kfinance_api_client=self.kfinance_api_client, security_id=self.security_id
+            )
+        return self._primary_security
 
-        self.primary_security = Security(
-            kfinance_api_client=self.kfinance_api_client, security_id=self.security_id
-        )
-        return self.primary_security
-
-    @cached_property
+    @property
     def company(self) -> Company:
         """Set and return the company for the object
 
         :return: The company returned as Company object
         :rtype: Company
         """
-        self.company = Company(
-            kfinance_api_client=self.kfinance_api_client, company_id=self.company_id
-        )
-        return self.company
+        if self._company is None:
+            self._company = Company(
+                kfinance_api_client=self.kfinance_api_client, company_id=self.company_id
+            )
+        return self._company
 
-    @cached_property
+    @property
     def primary_trading_item(self) -> TradingItem:
         """Set and return the trading item for the object
 
         :return: The trading item returned as TradingItem object
         :rtype: TradingItem
         """
-        self.primary_trading_item = TradingItem(
-            kfinance_api_client=self.kfinance_api_client, trading_item_id=self.trading_item_id
-        )
-        return self.primary_trading_item
+        if self._primary_trading_item is None:
+            self._primary_trading_item = TradingItem(
+                kfinance_api_client=self.kfinance_api_client, trading_item_id=self.trading_item_id
+            )
+        return self._primary_trading_item
 
-    @cached_property
+    @property
     def isin(self) -> str:
         """Get the ISIN for the object
 
@@ -869,7 +911,7 @@ class Ticker(DelegatedCompanyFunctionsMetaClass):
         self._isin = isin
         return isin
 
-    @cached_property
+    @property
     def cusip(self) -> str:
         """Get the CUSIP for the object
 
@@ -882,7 +924,7 @@ class Ticker(DelegatedCompanyFunctionsMetaClass):
         self._cusip = cusip
         return cusip
 
-    @cached_property
+    @property
     def info(self) -> dict:
         """Get the company info for the ticker
 
@@ -1008,7 +1050,7 @@ class Ticker(DelegatedCompanyFunctionsMetaClass):
         """
         return self.company.iso_country
 
-    @cached_property
+    @property
     def earnings_call_datetimes(self) -> list[datetime]:
         """Get the datetimes of the companies earnings calls
 
@@ -1017,7 +1059,7 @@ class Ticker(DelegatedCompanyFunctionsMetaClass):
         """
         return self.company.earnings_call_datetimes
 
-    @cached_property
+    @property
     def history_metadata(self) -> HistoryMetadata:
         """Get information about exchange and quotation
 
@@ -1031,7 +1073,7 @@ class Ticker(DelegatedCompanyFunctionsMetaClass):
             self._ticker = metadata["symbol"]
         return metadata
 
-    @cached_property
+    @property
     def ticker(self) -> str:
         """Get the ticker if it isn't available from initialization"""
         if self._ticker is not None:

--- a/kfinance/meta_classes.py
+++ b/kfinance/meta_classes.py
@@ -1,5 +1,5 @@
+from abc import abstractmethod
 from datetime import datetime
-from functools import cached_property
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional
 
@@ -21,7 +21,8 @@ logger = logging.getLogger(__name__)
 class CompanyFunctionsMetaClass:
     kfinance_api_client: KFinanceApiClient
 
-    @cached_property
+    @property
+    @abstractmethod
     def company_id(self) -> Any:
         """Set and return the company id for the object"""
         raise NotImplementedError("child classes must implement company id property")
@@ -213,6 +214,7 @@ class CompanyFunctionsMetaClass:
             .set_index(pd.Index([line_item]))
         )
 
+    @cached(cache=LRUCache(maxsize=100))
     def relationships(self, relationship_type: BusinessRelationshipType) -> "BusinessRelationships":
         """Returns a BusinessRelationships object that includes the current and previous Companies associated with company_id and filtered by relationship_type. The function calls fetch_companies_from_business_relationship.
 
@@ -494,7 +496,7 @@ class DelegatedCompanyFunctionsMetaClass(CompanyFunctionsMetaClass):
                 delegated_function(company_function_name),
             )
 
-    @cached_property
+    @property
     def company(self) -> Any:
         """Set and return the company for the object"""
         raise NotImplementedError("child classes must implement company property")
@@ -502,8 +504,8 @@ class DelegatedCompanyFunctionsMetaClass(CompanyFunctionsMetaClass):
 
 for relationship in BusinessRelationshipType:
 
-    def _relationship_outer_wrapper(relationship_type: BusinessRelationshipType) -> cached_property:
-        """Creates a cached property for a relationship type.
+    def _relationship_outer_wrapper(relationship_type: BusinessRelationshipType) -> property:
+        """Creates a property for a relationship type.
 
         This function returns a property that retrieves the associated company's current and previous
         relationships of the specified type.
@@ -512,7 +514,7 @@ for relationship in BusinessRelationshipType:
             relationship_type (BusinessRelationshipType): The type of relationship to be wrapped.
 
         Returns:
-            property: A cached property that calls the inner wrapper to retrieve the relationship data.
+            property: A property that calls the inner wrapper to retrieve the relationship data.
         """
 
         def relationship_inner_wrapper(
@@ -533,12 +535,11 @@ for relationship in BusinessRelationshipType:
         relationship_inner_wrapper.__doc__ = doc
         relationship_inner_wrapper.__name__ = relationship
 
-        return cached_property(relationship_inner_wrapper)
+        return property(relationship_inner_wrapper)
 
-    relationship_cached_property = _relationship_outer_wrapper(relationship)
-    relationship_cached_property.__set_name__(CompanyFunctionsMetaClass, relationship)
+    relationship_property = _relationship_outer_wrapper(relationship)
     setattr(
         CompanyFunctionsMetaClass,
         relationship,
-        relationship_cached_property,
+        relationship_property,
     )

--- a/kfinance/tests/test_batch_requests.py
+++ b/kfinance/tests/test_batch_requests.py
@@ -68,38 +68,6 @@ class TestTradingItem(TestCase):
             self.assertDictEqual(id_based_result, expected_id_based_result)
 
     @requests_mock.Mocker()
-    def test_batch_request_cached_properties(self, m):
-        """GIVEN a kfinance group object like Companies
-        WHEN we batch request a cached property for each object in the group
-        THEN the batch request completes successfully and we get back a mapping of
-        company objects to the corresponding values."""
-
-        m.get(
-            "https://kfinance.kensho.com/api/v1/securities/1001",
-            json={"securities": [101, 102, 103]},
-        )
-        m.get(
-            "https://kfinance.kensho.com/api/v1/securities/1002",
-            json={"securities": [104, 105, 106, 107]},
-        )
-        m.get("https://kfinance.kensho.com/api/v1/securities/1005", json={"securities": [108, 109]})
-
-        companies = Companies(self.kfinance_api_client, [1001, 1002, 1005])
-        result = companies.securities
-
-        id_based_result = self.company_object_keys_as_company_id(result)
-        for k, v in id_based_result.items():
-            id_based_result[k] = set(map(lambda s: s.security_id, v))
-
-        expected_id_based_result = {
-            1001: set([101, 102, 103]),
-            1002: set([104, 105, 106, 107]),
-            1005: set([108, 109]),
-        }
-
-        self.assertDictEqual(id_based_result, expected_id_based_result)
-
-    @requests_mock.Mocker()
     def test_batch_request_function(self, m):
         """GIVEN a kfinance group object like TradingItems
         WHEN we batch request a function for each object in the group


### PR DESCRIPTION
Cached properties don't work with our batching because they contain an undocumented lock (removed in python 3.12). 
https://onekensho.slack.com/archives/C07GN0HHCMD/p1748960552876639