### PR TITLE
bump urllib3 to 2.5

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# v2.6.3
+- Bump urllib3 to 2.5 to  address CVEs
+
 ## v2.6.2
  - Safely check for incomplete merger information
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "tabulate>=0.9.0",  # required for turning dataframes into markdown
     "types-requests>=2.22.0,<3",
     "requests>=2.22.0,<3",
-    "urllib3>=1.21.1",
+    "urllib3>=2.5",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Required by Anthropic because of CVEs in earlier versions.