### PR TITLE
remove transaction and advisor from company object

### DIFF
--- a/kfinance/tool_calling/get_advisors_for_company_in_transaction_from_identifier.py
+++ b/kfinance/tool_calling/get_advisors_for_company_in_transaction_from_identifier.py
@@ -2,7 +2,7 @@ from typing import Type
 
 from pydantic import BaseModel, Field
 
-from kfinance.kfinance import AdvisedCompany
+from kfinance.kfinance import Company, ParticipantInMerger
 from kfinance.models.permission_models import Permission
 from kfinance.tool_calling.shared_models import KfinanceTool, ToolArgsWithIdentifier
 
@@ -19,18 +19,21 @@ class GetAdvisorsForCompanyInTransactionFromIdentifier(KfinanceTool):
 
     def _run(self, identifier: str, transaction_id: int) -> list:
         ticker = self.kfinance_client.ticker(identifier)
-        advised_company = AdvisedCompany(
+        participant_in_merger = ParticipantInMerger(
             kfinance_api_client=ticker.kfinance_api_client,
-            company_id=ticker.company.company_id,
             transaction_id=transaction_id,
+            company=Company(
+                kfinance_api_client=ticker.kfinance_api_client,
+                company_id=ticker.company.company_id,
+            ),
         )
-        advisors = advised_company.advisors
+        advisors = participant_in_merger.advisors
 
         if advisors:
             return [
                 {
-                    "advisor_company_id": advisor.company_id,
-                    "advisor_company_name": advisor.name,
+                    "advisor_company_id": advisor.company.company_id,
+                    "advisor_company_name": advisor.company.name,
                     "advisor_type_name": advisor.advisor_type_name,
                 }
                 for advisor in advisors

--- a/kfinance/tool_calling/get_merger_info_from_transaction_id.py
+++ b/kfinance/tool_calling/get_merger_info_from_transaction_id.py
@@ -22,6 +22,7 @@ class GetMergerInfoFromTransactionId(KfinanceTool):
             kfinance_api_client=self.kfinance_client.kfinance_api_client,
             transaction_id=transaction_id,
             merger_title=None,
+            closed_date=None,
         )
         merger_timeline = merger_or_acquisition.get_timeline
         merger_participants = merger_or_acquisition.get_participants
@@ -36,15 +37,15 @@ class GetMergerInfoFromTransactionId(KfinanceTool):
             else None,
             "participants": {
                 "target": {
-                    "company_id": merger_participants["target"].company_id,
-                    "company_name": merger_participants["target"].name,
+                    "company_id": merger_participants["target"].company.company_id,
+                    "company_name": merger_participants["target"].company.name,
                 },
                 "buyers": [
-                    {"company_id": buyer.company_id, "company_name": buyer.name}
+                    {"company_id": buyer.company.company_id, "company_name": buyer.company.name}
                     for buyer in merger_participants["buyers"]
                 ],
                 "sellers": [
-                    {"company_id": seller.company_id, "company_name": seller.name}
+                    {"company_id": seller.company.company_id, "company_name": seller.company.name}
                     for seller in merger_participants["sellers"]
                 ],
             }

--- a/kfinance/tool_calling/get_mergers_from_identifier.py
+++ b/kfinance/tool_calling/get_mergers_from_identifier.py
@@ -21,6 +21,7 @@ class GetMergersFromIdentifier(KfinanceTool):
                 {
                     "transaction_id": merger_or_acquisition.transaction_id,
                     "merger_title": merger_or_acquisition.merger_title,
+                    "closed_date": merger_or_acquisition.closed_date,
                 }
                 for merger_or_acquisition in mergers_and_acquisitions["target"]
             ],
@@ -28,6 +29,7 @@ class GetMergersFromIdentifier(KfinanceTool):
                 {
                     "transaction_id": merger_or_acquisition.transaction_id,
                     "merger_title": merger_or_acquisition.merger_title,
+                    "closed_date": merger_or_acquisition.closed_date,
                 }
                 for merger_or_acquisition in mergers_and_acquisitions["buyer"]
             ],
@@ -35,6 +37,7 @@ class GetMergersFromIdentifier(KfinanceTool):
                 {
                     "transaction_id": merger_or_acquisition.transaction_id,
                     "merger_title": merger_or_acquisition.merger_title,
+                    "closed_date": merger_or_acquisition.closed_date,
                 }
                 for merger_or_acquisition in mergers_and_acquisitions["seller"]
             ],


### PR DESCRIPTION
1) Eventually there will be more kinds of transactions that `Company` objects will be involved with than just mergers, and each of those will need a different advisors lookup property. So, rather than try to extend the `Company` or the `AdvisedCompany` objects further, I just broke the transaction information away from the `Company` object entirely. So for right now there's a new object `ParticipantInMerger` with a custom `advisors` property and a child `Company` property, and another new object `Advisor` with an `advisor_type_name` property and a similar child `Company` property.

2) Now that `closed_date` is present in the list output for mergers, I wanted to include that in the tool call output.