### PR TITLE
limit FastMCP version to prevent errors

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.9.0
+- Add currency to get_capitalization and get_prices tools.
+
 ## v2.8.0
 - Add currency to get_capitalization and get_prices tools.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
     "cachetools>=5.5,<6",
     "click>=8.2.1,<=9",
-    "fastmcp>=2,<3",
+    "fastmcp>=2.9,<2.10",
     "langchain-core>=0.3.15",
     "langchain-google-genai>=2.1.5,<3",
     "numpy>=1.22.4",


### PR DESCRIPTION
Currently encountering unexpected validation error when running on the latest FastMCP version (2.10.6), limiting to FastMCP 2.9.X