### PR TITLE
Disable low level mcp sdk validation

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v3.2.3
+- Disable low level MCP SDK input validation
+
 ## v3.2.2
 - Use ValidQuarter for statement and line item tools
 

--- a/kfinance/integrations/local_mcp/kfinance_mcp.py
+++ b/kfinance/integrations/local_mcp/kfinance_mcp.py
@@ -1,0 +1,22 @@
+from fastmcp import FastMCP
+
+
+class KfinanceMcp(FastMCP):
+    """FastMCP subclass with some kfinance specific adaptations."""
+
+    def _setup_handlers(self) -> None:
+        """Skip low level input validation for tool calls.
+
+        We do validate inputs as part of KfinanceTool.run_without_langchain.
+        However, the mcp python sdk recently added its own low-level validation:
+        github.com/modelcontextprotocol/python-sdk/commit/c8bbfc034d5cb876d6b91185cf02da2af6fb8b44
+        This causes problems because claude always returns integer values as strings if
+        they are part of a field that allows multiple types. e.g. `start_year: int | None`
+        -> Claude will always return strings. This is fine for pydantic, it automatically
+        converts the strings to integers.
+        However, the mcp sdk validation is stricter and disallows strings where ints are
+        required.
+        call_tool(validate_input=False) turns off the mcp sdk validation.
+        """
+        super()._setup_handlers()
+        self._mcp_server.call_tool(validate_input=False)(self._mcp_call_tool)

--- a/kfinance/integrations/local_mcp/local_mcp.py
+++ b/kfinance/integrations/local_mcp/local_mcp.py
@@ -1,12 +1,12 @@
 from typing import Literal, Optional
 
 import click
-from fastmcp import FastMCP
 from fastmcp.tools import FunctionTool
 from fastmcp.utilities.logging import get_logger
 from langchain_core.utils.function_calling import convert_to_openai_tool
 
 from kfinance.client.kfinance import Client
+from kfinance.integrations.local_mcp.kfinance_mcp import KfinanceMcp
 from kfinance.integrations.tool_calling.tool_calling_models import KfinanceTool
 
 
@@ -76,7 +76,7 @@ def run_mcp(
         logger.info("The client will be authenticated using a browser")
         kfinance_client = Client()
 
-    kfinance_mcp: FastMCP = FastMCP("Kfinance")
+    kfinance_mcp: KfinanceMcp = KfinanceMcp("Kfinance")
     for langchain_tool in kfinance_client.langchain_tools:
         logger.info("Adding %s to server", langchain_tool.name)
         kfinance_mcp.add_tool(build_mcp_tool_from_kfinance_tool(langchain_tool))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
     "cachetools>=5.5,<6",
     "click>=8.2.1,<=9",
-    "fastmcp>=2.9,<2.10",
+    "fastmcp>=2.11",
     "langchain-core>=0.3.15",
     "langchain-google-genai>=2.1.5,<3",
     "numpy>=1.22.4",


### PR DESCRIPTION
Disabling low level mcp sdk validation allows us to update fastmcp and mcp dependencies. 

I need updated fastmcp for hosted mcp (which depends on this library, which in turn depends on earlier fastmcp and mcp versions).
<img width="820" height="419" alt="Screenshot 2025-08-18 at 2 06 57 PM" src="https://github.com/user-attachments/assets/cee89b7d-94df-47f8-924a-6777bec11b2b" />

