### PR TITLE
Return pydantic model from tool._run

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# v3.2.5
+- Return pydantic models from KfinanceTool._run
+
 ## v3.2.4
 - Add Mergers & Acquisitions tools to ALL_TOOLS
 

--- a/kfinance/client/fetch.py
+++ b/kfinance/client/fetch.py
@@ -26,7 +26,10 @@ from kfinance.domains.companies.company_models import (
 from kfinance.domains.competitors.competitor_models import CompetitorResponse, CompetitorSource
 from kfinance.domains.earnings.earning_models import EarningsCallResp
 from kfinance.domains.line_items.line_item_models import LineItemResponse
-from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_models import MergersResp
+from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_models import (
+    MergerInfo,
+    MergersResp,
+)
 from kfinance.domains.prices.price_models import HistoryMetadataResp, PriceHistory
 from kfinance.domains.segments.segment_models import SegmentsResp, SegmentType
 from kfinance.domains.statements.statement_models import StatementsResp
@@ -645,17 +648,16 @@ class KFinanceApiClient:
     def fetch_merger_info(
         self,
         transaction_id: int,
-    ) -> dict:
+    ) -> MergerInfo:
         """Fetches information about the given merger or acquisition, including the timeline, the participants, and the considerations.
 
-        Returns a complex dictionary.
         :param transaction_id: The transaction ID to filter on.
         :type transaction_id: int
         :return: A dictionary containing the timeline, the participants, and the considerations (eith their details) of the transaction.
-        :rtype: dict
+        :rtype: MergerInfo
         """
         url = f"{self.url_base}merger/info/{transaction_id}"
-        return self.fetch(url)
+        return MergerInfo.model_validate(self.fetch(url))
 
     def fetch_advisors_for_company_in_merger(
         self,

--- a/kfinance/client/models/date_and_period_models.py
+++ b/kfinance/client/models/date_and_period_models.py
@@ -1,5 +1,6 @@
-from typing import TypedDict
+from datetime import date
 
+from pydantic import BaseModel
 from strenum import StrEnum
 
 
@@ -21,28 +22,28 @@ class Periodicity(StrEnum):
     year = "year"
 
 
-class YearAndQuarter(TypedDict):
+class YearAndQuarter(BaseModel):
     year: int
     quarter: int
 
 
-class LatestAnnualPeriod(TypedDict):
+class LatestAnnualPeriod(BaseModel):
     latest_year: int
 
 
-class LatestQuarterlyPeriod(TypedDict):
+class LatestQuarterlyPeriod(BaseModel):
     latest_quarter: int
     latest_year: int
 
 
-class CurrentPeriod(TypedDict):
+class CurrentPeriod(BaseModel):
     current_year: int
     current_quarter: int
     current_month: int
-    current_date: str
+    current_date: date
 
 
-class LatestPeriods(TypedDict):
+class LatestPeriods(BaseModel):
     annual: LatestAnnualPeriod
     quarterly: LatestQuarterlyPeriod
     now: CurrentPeriod

--- a/kfinance/client/tests/test_fetch.py
+++ b/kfinance/client/tests/test_fetch.py
@@ -311,7 +311,9 @@ class TestFetchItem(TestCase):
     def test_fetch_merger_info(self) -> None:
         transaction_id = 554979212
         expected_fetch_url = f"{self.kfinance_api_client.url_base}merger/info/{transaction_id}"
-        self.kfinance_api_client.fetch_merger_info(transaction_id=transaction_id)
+        # Validation error is ok, we only care that the function was called with the correct url
+        with pytest.raises(ValidationError):
+            self.kfinance_api_client.fetch_merger_info(transaction_id=transaction_id)
         self.kfinance_api_client.fetch.assert_called_with(expected_fetch_url)
 
     def test_fetch_advisors_for_company_in_merger(self) -> None:

--- a/kfinance/domains/business_relationships/business_relationship_tools.py
+++ b/kfinance/domains/business_relationships/business_relationship_tools.py
@@ -38,7 +38,9 @@ class GetBusinessRelationshipFromIdentifiers(KfinanceTool):
     args_schema: Type[BaseModel] = GetBusinessRelationshipFromIdentifiersArgs
     accepted_permissions: set[Permission] | None = {Permission.RelationshipPermission}
 
-    def _run(self, identifiers: list[str], business_relationship: BusinessRelationshipType) -> dict:
+    def _run(
+        self, identifiers: list[str], business_relationship: BusinessRelationshipType
+    ) -> GetBusinessRelationshipFromIdentifiersResp:
         """Sample response:
 
         {
@@ -76,10 +78,8 @@ class GetBusinessRelationshipFromIdentifiers(KfinanceTool):
             api_client=api_client, tasks=tasks
         )
 
-        output_model = GetBusinessRelationshipFromIdentifiersResp(
+        return GetBusinessRelationshipFromIdentifiersResp(
             business_relationship=business_relationship,
             results=relationship_responses,
             errors=list(id_triple_resp.errors.values()),
         )
-
-        return output_model.model_dump(mode="json")

--- a/kfinance/domains/business_relationships/tests/test_business_relationship_tools.py
+++ b/kfinance/domains/business_relationships/tests/test_business_relationship_tools.py
@@ -8,6 +8,7 @@ from kfinance.domains.business_relationships.business_relationship_models import
 from kfinance.domains.business_relationships.business_relationship_tools import (
     GetBusinessRelationshipFromIdentifiers,
     GetBusinessRelationshipFromIdentifiersArgs,
+    GetBusinessRelationshipFromIdentifiersResp,
 )
 
 
@@ -27,21 +28,23 @@ class TestGetBusinessRelationshipFromIdentifiers:
                 {"company_id": 8182358, "company_name": "Eloqua, Inc."},
             ],
         }
-        expected_result = {
-            "business_relationship": "supplier",
-            "results": {
-                "SPGI": {
-                    "current": [{"company_id": "C_883103", "company_name": "CRISIL Limited"}],
-                    "previous": [
-                        {"company_id": "C_472898", "company_name": "Morgan Stanley"},
-                        {"company_id": "C_8182358", "company_name": "Eloqua, Inc."},
-                    ],
-                }
-            },
-            "errors": [
-                "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
-            ],
-        }
+        expected_result = GetBusinessRelationshipFromIdentifiersResp.model_validate(
+            {
+                "business_relationship": "supplier",
+                "results": {
+                    "SPGI": {
+                        "current": [{"company_id": 883103, "company_name": "CRISIL Limited"}],
+                        "previous": [
+                            {"company_id": 472898, "company_name": "Morgan Stanley"},
+                            {"company_id": 8182358, "company_name": "Eloqua, Inc."},
+                        ],
+                    }
+                },
+                "errors": [
+                    "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
+                ],
+            }
+        )
 
         requests_mock.get(
             url=f"https://kfinance.kensho.com/api/v1/relationship/{SPGI_COMPANY_ID}/supplier",
@@ -54,5 +57,4 @@ class TestGetBusinessRelationshipFromIdentifiers:
             business_relationship=BusinessRelationshipType.supplier,
         )
         resp = tool.run(args.model_dump(mode="json"))
-        resp["results"]["SPGI"]["previous"].sort(key=lambda x: x["company_id"])
         assert resp == expected_result

--- a/kfinance/domains/capitalizations/capitalization_models.py
+++ b/kfinance/domains/capitalizations/capitalization_models.py
@@ -20,9 +20,9 @@ class DailyCapitalization(BaseModel):
     """DailyCapitalization represents market cap, TEV, and shares outstanding for a day"""
 
     date: date
-    market_cap: Money
-    tev: Money
-    shares_outstanding: Shares
+    market_cap: Money | None
+    tev: Money | None
+    shares_outstanding: Shares | None
 
 
 class Capitalizations(BaseModel):

--- a/kfinance/domains/capitalizations/capitalization_tools.py
+++ b/kfinance/domains/capitalizations/capitalization_tools.py
@@ -26,6 +26,7 @@ class GetCapitalizationFromIdentifiersArgs(ToolArgsWithIdentifiers):
 
 
 class GetCapitalizationFromIdentifiersResp(ToolRespWithErrors):
+    capitalization: Capitalization
     results: dict[str, Capitalizations]
 
 
@@ -50,13 +51,13 @@ class GetCapitalizationFromIdentifiers(KfinanceTool):
         capitalization: Capitalization,
         start_date: str | None = None,
         end_date: str | None = None,
-    ) -> dict:
+    ) -> GetCapitalizationFromIdentifiersResp:
         """Sample response:
 
         {
+            'capitalization': 'market_cap'
             'results': {
                 'SPGI': {
-                    'capitalizations': [
                         {'date': '2024-04-10', 'market_cap': {'value': '132766738270.00', 'unit': 'USD'}},
                         {'date': '2024-04-11', 'market_cap': {'value': '132416066761.00', 'unit': 'USD'}}
                     ]
@@ -100,7 +101,8 @@ class GetCapitalizationFromIdentifiers(KfinanceTool):
                 if capitalization is not Capitalization.shares_outstanding:
                     daily_capitalization.shares_outstanding = None
 
-        resp_model = GetCapitalizationFromIdentifiersResp(
-            results=capitalization_responses, errors=list(id_triple_resp.errors.values())
+        return GetCapitalizationFromIdentifiersResp(
+            capitalization=capitalization,
+            results=capitalization_responses,
+            errors=list(id_triple_resp.errors.values()),
         )
-        return resp_model.model_dump(mode="json", exclude_none=True)

--- a/kfinance/domains/companies/company_tools.py
+++ b/kfinance/domains/companies/company_tools.py
@@ -27,7 +27,7 @@ class GetInfoFromIdentifiers(KfinanceTool):
     args_schema: Type[BaseModel] = ToolArgsWithIdentifiers
     accepted_permissions: set[Permission] | None = None
 
-    def _run(self, identifiers: list[str]) -> dict:
+    def _run(self, identifiers: list[str]) -> GetInfoFromIdentifiersResp:
         """Sample response:
 
         {   "results": {
@@ -65,10 +65,9 @@ class GetInfoFromIdentifiers(KfinanceTool):
         info_responses: dict[str, dict] = process_tasks_in_thread_pool_executor(
             api_client=api_client, tasks=tasks
         )
-        resp_model = GetInfoFromIdentifiersResp(
+        return GetInfoFromIdentifiersResp(
             results=info_responses, errors=list(id_triple_resp.errors.values())
         )
-        return resp_model.model_dump(mode="json")
 
 
 class GetCompanyOtherNamesFromIdentifiersResp(ToolRespWithErrors):
@@ -88,7 +87,7 @@ class GetCompanyOtherNamesFromIdentifiers(KfinanceTool):
     def _run(
         self,
         identifiers: list[str],
-    ) -> dict:
+    ) -> GetCompanyOtherNamesFromIdentifiersResp:
         api_client = self.kfinance_client.kfinance_api_client
         id_triple_resp = api_client.unified_fetch_id_triples(identifiers=identifiers)
         tasks = [
@@ -102,10 +101,9 @@ class GetCompanyOtherNamesFromIdentifiers(KfinanceTool):
         info_responses: dict[str, CompanyOtherNames] = process_tasks_in_thread_pool_executor(
             api_client=api_client, tasks=tasks
         )
-        resp_model = GetCompanyOtherNamesFromIdentifiersResp(
+        return GetCompanyOtherNamesFromIdentifiersResp(
             results=info_responses, errors=list(id_triple_resp.errors.values())
         )
-        return resp_model.model_dump(mode="json")
 
 
 class GetCompanySummaryFromIdentifiersResp(ToolRespWithErrors):
@@ -125,7 +123,7 @@ class GetCompanySummaryFromIdentifiers(KfinanceTool):
     def _run(
         self,
         identifiers: list[str],
-    ) -> dict:
+    ) -> GetCompanySummaryFromIdentifiersResp:
         api_client = self.kfinance_client.kfinance_api_client
         id_triple_resp = api_client.unified_fetch_id_triples(identifiers=identifiers)
 
@@ -147,10 +145,9 @@ class GetCompanySummaryFromIdentifiers(KfinanceTool):
             for identifier, descriptions in company_description_responses.items()
         }
 
-        resp_model = GetCompanySummaryFromIdentifiersResp(
+        return GetCompanySummaryFromIdentifiersResp(
             results=summary_results, errors=list(id_triple_resp.errors.values())
         )
-        return resp_model.model_dump(mode="json")
 
 
 class GetCompanyDescriptionFromIdentifiersResp(ToolRespWithErrors):
@@ -170,7 +167,7 @@ class GetCompanyDescriptionFromIdentifiers(KfinanceTool):
     def _run(
         self,
         identifiers: list[str],
-    ) -> dict:
+    ) -> GetCompanyDescriptionFromIdentifiersResp:
         api_client = self.kfinance_client.kfinance_api_client
         id_triple_resp = api_client.unified_fetch_id_triples(identifiers=identifiers)
 
@@ -192,7 +189,6 @@ class GetCompanyDescriptionFromIdentifiers(KfinanceTool):
             for identifier, descriptions in company_description_responses.items()
         }
 
-        resp_model = GetCompanyDescriptionFromIdentifiersResp(
+        return GetCompanyDescriptionFromIdentifiersResp(
             results=description_results, errors=list(id_triple_resp.errors.values())
         )
-        return resp_model.model_dump(mode="json")

--- a/kfinance/domains/companies/tests/test_company_tools.py
+++ b/kfinance/domains/companies/tests/test_company_tools.py
@@ -4,9 +4,13 @@ from kfinance.client.kfinance import Client
 from kfinance.conftest import SPGI_COMPANY_ID
 from kfinance.domains.companies.company_tools import (
     GetCompanyDescriptionFromIdentifiers,
+    GetCompanyDescriptionFromIdentifiersResp,
     GetCompanyOtherNamesFromIdentifiers,
+    GetCompanyOtherNamesFromIdentifiersResp,
     GetCompanySummaryFromIdentifiers,
+    GetCompanySummaryFromIdentifiersResp,
     GetInfoFromIdentifiers,
+    GetInfoFromIdentifiersResp,
 )
 from kfinance.integrations.tool_calling.tool_calling_models import ToolArgsWithIdentifiers
 
@@ -20,12 +24,14 @@ class TestGetInfoFromIdentifiers:
         """
 
         info_resp = {"name": "S&P Global Inc.", "status": "Operating"}
-        expected_response = {
-            "results": {"SPGI": info_resp},
-            "errors": [
-                "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
-            ],
-        }
+        expected_response = GetInfoFromIdentifiersResp.model_validate(
+            {
+                "results": {"SPGI": info_resp},
+                "errors": [
+                    "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
+                ],
+            }
+        )
         requests_mock.get(
             url=f"https://kfinance.kensho.com/api/v1/info/{SPGI_COMPANY_ID}",
             json=info_resp,
@@ -61,7 +67,9 @@ class TestGetCompanyDescriptions:
         tool = GetCompanySummaryFromIdentifiers(kfinance_client=mock_client)
         args = ToolArgsWithIdentifiers(identifiers=["SPGI"])
         response = tool.run(args.model_dump(mode="json"))
-        expected_response = {"results": {"SPGI": self.summary}}
+        expected_response = GetCompanySummaryFromIdentifiersResp.model_validate(
+            {"results": {"SPGI": self.summary}}
+        )
         assert response == expected_response
 
     def test_get_company_description_from_identifier(
@@ -81,7 +89,9 @@ class TestGetCompanyDescriptions:
         tool = GetCompanyDescriptionFromIdentifiers(kfinance_client=mock_client)
         args = ToolArgsWithIdentifiers(identifiers=["SPGI"])
         response = tool.run(args.model_dump(mode="json"))
-        expected_response = {"results": {"SPGI": self.description}}
+        expected_response = GetCompanyDescriptionFromIdentifiersResp.model_validate(
+            {"results": {"SPGI": self.description}}
+        )
         assert response == expected_response
 
 
@@ -121,5 +131,7 @@ class TestGetCompanyOtherNames:
         tool = GetCompanyOtherNamesFromIdentifiers(kfinance_client=mock_client)
         args = ToolArgsWithIdentifiers(identifiers=["SPGI"])
         response = tool.run(args.model_dump(mode="json"))
-        expected_response = {"results": {"SPGI": self.company_other_names_info}}
+        expected_response = GetCompanyOtherNamesFromIdentifiersResp.model_validate(
+            {"results": {"SPGI": self.company_other_names_info}}
+        )
         assert response == expected_response

--- a/kfinance/domains/competitors/competitor_tools.py
+++ b/kfinance/domains/competitors/competitor_tools.py
@@ -27,7 +27,7 @@ class GetCompetitorsFromIdentifiers(KfinanceTool):
         self,
         identifiers: list[str],
         competitor_source: CompetitorSource,
-    ) -> dict:
+    ) -> GetCompetitorsFromIdentifiersResp:
         """Sample response:
 
         {
@@ -56,7 +56,6 @@ class GetCompetitorsFromIdentifiers(KfinanceTool):
         competitor_responses: dict[str, CompetitorResponse] = process_tasks_in_thread_pool_executor(
             api_client=api_client, tasks=tasks
         )
-        resp_model = GetCompetitorsFromIdentifiersResp(
+        return GetCompetitorsFromIdentifiersResp(
             results=competitor_responses, errors=list(id_triple_resp.errors.values())
         )
-        return resp_model.model_dump(mode="json")

--- a/kfinance/domains/competitors/tests/test_competitor_tools.py
+++ b/kfinance/domains/competitors/tests/test_competitor_tools.py
@@ -6,6 +6,7 @@ from kfinance.domains.competitors.competitor_models import CompetitorSource
 from kfinance.domains.competitors.competitor_tools import (
     GetCompetitorsFromIdentifiers,
     GetCompetitorsFromIdentifiersArgs,
+    GetCompetitorsFromIdentifiersResp,
 )
 
 
@@ -24,25 +25,27 @@ class TestGetCompetitorsFromIdentifiers:
                 {"company_id": 4003514, "company_name": "London Stock Exchange Group plc"},
             ]
         }
-        expected_response = {
-            "results": {
-                "SPGI": {
-                    "competitors": [
-                        {
-                            "company_id": "C_35352",
-                            "company_name": "The Descartes Systems Group Inc.",
-                        },
-                        {
-                            "company_id": "C_4003514",
-                            "company_name": "London Stock Exchange Group plc",
-                        },
-                    ]
-                }
-            },
-            "errors": [
-                "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
-            ],
-        }
+        expected_response = GetCompetitorsFromIdentifiersResp.model_validate(
+            {
+                "results": {
+                    "SPGI": {
+                        "competitors": [
+                            {
+                                "company_id": 35352,
+                                "company_name": "The Descartes Systems Group Inc.",
+                            },
+                            {
+                                "company_id": 4003514,
+                                "company_name": "London Stock Exchange Group plc",
+                            },
+                        ]
+                    }
+                },
+                "errors": [
+                    "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
+                ],
+            }
+        )
 
         requests_mock.get(
             url=f"https://kfinance.kensho.com/api/v1/competitors/{SPGI_COMPANY_ID}/named_by_competitor",

--- a/kfinance/domains/cusip_and_isin/cusip_and_isin_tools.py
+++ b/kfinance/domains/cusip_and_isin/cusip_and_isin_tools.py
@@ -23,7 +23,7 @@ class GetCusipFromIdentifiers(KfinanceTool):
     args_schema: Type[BaseModel] = ToolArgsWithIdentifiers
     accepted_permissions: set[Permission] | None = {Permission.IDPermission}
 
-    def _run(self, identifiers: list[str]) -> dict[str, str]:
+    def _run(self, identifiers: list[str]) -> GetCusipOrIsinFromIdentifiersResp:
         """Sample response:
 
         {
@@ -45,14 +45,13 @@ class GetCusipFromIdentifiers(KfinanceTool):
         ]
 
         cusip_responses = process_tasks_in_thread_pool_executor(api_client=api_client, tasks=tasks)
-        resp_model = GetCusipOrIsinFromIdentifiersResp(
+        return GetCusipOrIsinFromIdentifiersResp(
             results={
                 identifier: cusip_resp["cusip"]
                 for identifier, cusip_resp in cusip_responses.items()
             },
             errors=list(id_triple_resp.errors.values()),
         )
-        return resp_model.model_dump(mode="json")
 
 
 class GetIsinFromIdentifiers(KfinanceTool):
@@ -61,7 +60,7 @@ class GetIsinFromIdentifiers(KfinanceTool):
     args_schema: Type[BaseModel] = ToolArgsWithIdentifiers
     accepted_permissions: set[Permission] | None = {Permission.IDPermission}
 
-    def _run(self, identifiers: list[str]) -> dict:
+    def _run(self, identifiers: list[str]) -> GetCusipOrIsinFromIdentifiersResp:
         """Sample response:
 
         {
@@ -83,10 +82,9 @@ class GetIsinFromIdentifiers(KfinanceTool):
         ]
 
         isin_responses = process_tasks_in_thread_pool_executor(api_client=api_client, tasks=tasks)
-        resp_model = GetCusipOrIsinFromIdentifiersResp(
+        return GetCusipOrIsinFromIdentifiersResp(
             results={
                 identifier: isin_resp["isin"] for identifier, isin_resp in isin_responses.items()
             },
             errors=list(id_triple_resp.errors.values()),
         )
-        return resp_model.model_dump(mode="json")

--- a/kfinance/domains/cusip_and_isin/tests/test_cusip_and_isin_tools.py
+++ b/kfinance/domains/cusip_and_isin/tests/test_cusip_and_isin_tools.py
@@ -4,6 +4,7 @@ from kfinance.client.kfinance import Client
 from kfinance.conftest import SPGI_SECURITY_ID
 from kfinance.domains.cusip_and_isin.cusip_and_isin_tools import (
     GetCusipFromIdentifiers,
+    GetCusipOrIsinFromIdentifiersResp,
     GetIsinFromIdentifiers,
 )
 from kfinance.integrations.tool_calling.tool_calling_models import ToolArgsWithIdentifiers
@@ -18,10 +19,12 @@ class TestGetCusipFromIdentifiers:
         """
 
         spgi_cusip = "78409V104"
-        expected_response = {
-            "results": {"SPGI": "78409V104"},
-            "errors": ["private_company is a private company without a security_id."],
-        }
+        expected_response = GetCusipOrIsinFromIdentifiersResp.model_validate(
+            {
+                "results": {"SPGI": "78409V104"},
+                "errors": ["private_company is a private company without a security_id."],
+            }
+        )
         requests_mock.get(
             url=f"https://kfinance.kensho.com/api/v1/cusip/{SPGI_SECURITY_ID}",
             json={"cusip": spgi_cusip},
@@ -43,10 +46,12 @@ class TestGetIsinFromIdentifiers:
 
         spgi_isin = "US78409V1044"
 
-        expected_response = {
-            "results": {"SPGI": "US78409V1044"},
-            "errors": ["private_company is a private company without a security_id."],
-        }
+        expected_response = GetCusipOrIsinFromIdentifiersResp.model_validate(
+            {
+                "results": {"SPGI": "US78409V1044"},
+                "errors": ["private_company is a private company without a security_id."],
+            }
+        )
         requests_mock.get(
             url=f"https://kfinance.kensho.com/api/v1/isin/{SPGI_SECURITY_ID}",
             json={"isin": spgi_isin},

--- a/kfinance/domains/earnings/earning_tools.py
+++ b/kfinance/domains/earnings/earning_tools.py
@@ -35,7 +35,7 @@ class GetEarningsFromIdentifiers(KfinanceTool):
         Permission.TranscriptsPermission,
     }
 
-    def _run(self, identifiers: list[str]) -> dict:
+    def _run(self, identifiers: list[str]) -> GetEarningsFromIdentifiersResp:
         """Sample response:
 
         {
@@ -52,10 +52,9 @@ class GetEarningsFromIdentifiers(KfinanceTool):
         }
 
         """
-        earnings_responses = get_earnings_from_identifiers(
+        return get_earnings_from_identifiers(
             identifiers=identifiers, kfinance_api_client=self.kfinance_client.kfinance_api_client
         )
-        return earnings_responses.model_dump(mode="json")
 
 
 class GetLatestEarningsFromIdentifiers(KfinanceTool):
@@ -71,7 +70,7 @@ class GetLatestEarningsFromIdentifiers(KfinanceTool):
         Permission.TranscriptsPermission,
     }
 
-    def _run(self, identifiers: list[str]) -> dict:
+    def _run(self, identifiers: list[str]) -> GetNextOrLatestEarningsFromIdentifiersResp:
         """Sample response:
 
         {
@@ -95,7 +94,7 @@ class GetLatestEarningsFromIdentifiers(KfinanceTool):
                 output_model.results[identifier] = most_recent_earnings
             else:
                 output_model.errors.append(f"No latest earnings available for {identifier}.")
-        return output_model.model_dump(mode="json")
+        return output_model
 
 
 class GetNextEarningsFromIdentifiers(KfinanceTool):
@@ -111,7 +110,7 @@ class GetNextEarningsFromIdentifiers(KfinanceTool):
         Permission.TranscriptsPermission,
     }
 
-    def _run(self, identifiers: list[str]) -> dict:
+    def _run(self, identifiers: list[str]) -> GetNextOrLatestEarningsFromIdentifiersResp:
         """Sample response:
 
         {
@@ -135,7 +134,7 @@ class GetNextEarningsFromIdentifiers(KfinanceTool):
                 output_model.results[identifier] = next_earnings
             else:
                 output_model.errors.append(f"No next earnings available for {identifier}.")
-        return output_model.model_dump(mode="json")
+        return output_model
 
 
 def get_earnings_from_identifiers(
@@ -170,12 +169,16 @@ class GetTranscriptFromKeyDevIdArgs(BaseModel):
     key_dev_id: int = Field(description="The key dev ID for the earnings call")
 
 
+class GetTranscriptFromKeyDevIdResp(BaseModel):
+    transcript: str
+
+
 class GetTranscriptFromKeyDevId(KfinanceTool):
     name: str = "get_transcript_from_key_dev_id"
     description: str = "Get the raw transcript text for an earnings call by key dev ID."
     args_schema: Type[BaseModel] = GetTranscriptFromKeyDevIdArgs
     accepted_permissions: set[Permission] | None = {Permission.TranscriptsPermission}
 
-    def _run(self, key_dev_id: int) -> str:
+    def _run(self, key_dev_id: int) -> GetTranscriptFromKeyDevIdResp:
         transcript = self.kfinance_client.transcript(key_dev_id)
-        return transcript.raw
+        return GetTranscriptFromKeyDevIdResp(transcript=transcript.raw)

--- a/kfinance/domains/earnings/tests/test_earnings_tools.py
+++ b/kfinance/domains/earnings/tests/test_earnings_tools.py
@@ -7,10 +7,13 @@ from kfinance.client.kfinance import Client
 from kfinance.conftest import SPGI_COMPANY_ID
 from kfinance.domains.earnings.earning_tools import (
     GetEarningsFromIdentifiers,
+    GetEarningsFromIdentifiersResp,
     GetLatestEarningsFromIdentifiers,
     GetNextEarningsFromIdentifiers,
+    GetNextOrLatestEarningsFromIdentifiersResp,
     GetTranscriptFromKeyDevId,
     GetTranscriptFromKeyDevIdArgs,
+    GetTranscriptFromKeyDevIdResp,
 )
 from kfinance.integrations.tool_calling.tool_calling_models import ToolArgsWithIdentifiers
 
@@ -43,27 +46,29 @@ class TestGetEarnings:
             json=self.earnings_response,
         )
 
-        expected_response = {
-            "results": {
-                "SPGI": {
-                    "earnings_calls": [
-                        {
-                            "name": "SPGI Q1 2025 Earnings Call",
-                            "key_dev_id": 12346,
-                            "datetime": "2025-04-29T12:30:00Z",
-                        },
-                        {
-                            "name": "SPGI Q4 2024 Earnings Call",
-                            "key_dev_id": 12345,
-                            "datetime": "2025-02-11T13:30:00Z",
-                        },
-                    ]
-                }
-            },
-            "errors": [
-                "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
-            ],
-        }
+        expected_response = GetEarningsFromIdentifiersResp.model_validate(
+            {
+                "results": {
+                    "SPGI": {
+                        "earnings": [
+                            {
+                                "name": "SPGI Q1 2025 Earnings Call",
+                                "key_dev_id": 12346,
+                                "datetime": "2025-04-29T12:30:00Z",
+                            },
+                            {
+                                "name": "SPGI Q4 2024 Earnings Call",
+                                "key_dev_id": 12345,
+                                "datetime": "2025-02-11T13:30:00Z",
+                            },
+                        ]
+                    }
+                },
+                "errors": [
+                    "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
+                ],
+            }
+        )
 
         tool = GetEarningsFromIdentifiers(kfinance_client=mock_client)
         response = tool.run(
@@ -95,16 +100,18 @@ class TestGetEarnings:
             json={"earnings": []},
         )
 
-        expected_response = {
-            "results": {
-                "SPGI": {
-                    "name": "SPGI Q1 2025 Earnings Call",
-                    "key_dev_id": 12346,
-                    "datetime": "2025-04-29T12:30:00Z",
-                }
-            },
-            "errors": ["No latest earnings available for private_company."],
-        }
+        expected_response = GetNextOrLatestEarningsFromIdentifiersResp.model_validate(
+            {
+                "results": {
+                    "SPGI": {
+                        "name": "SPGI Q1 2025 Earnings Call",
+                        "key_dev_id": 12346,
+                        "datetime": "2025-04-29T12:30:00Z",
+                    }
+                },
+                "errors": ["No latest earnings available for private_company."],
+            }
+        )
 
         tool = GetLatestEarningsFromIdentifiers(kfinance_client=mock_client)
         response = tool.run(
@@ -136,16 +143,18 @@ class TestGetEarnings:
             json={"earnings": []},
         )
 
-        expected_response = {
-            "results": {
-                "SPGI": {
-                    "datetime": "2025-04-29T12:30:00Z",
-                    "key_dev_id": 12346,
-                    "name": "SPGI Q1 2025 Earnings Call",
-                }
-            },
-            "errors": ["No next earnings available for private_company."],
-        }
+        expected_response = GetNextOrLatestEarningsFromIdentifiersResp.model_validate(
+            {
+                "results": {
+                    "SPGI": {
+                        "datetime": "2025-04-29T12:30:00Z",
+                        "key_dev_id": 12346,
+                        "name": "SPGI Q1 2025 Earnings Call",
+                    }
+                },
+                "errors": ["No next earnings available for private_company."],
+            }
+        )
 
         tool = GetNextEarningsFromIdentifiers(kfinance_client=mock_client)
         response = tool.run(
@@ -181,8 +190,8 @@ class TestGetTranscript:
             json=transcript_data,
         )
 
-        expected_response = (
-            "Operator: Good morning, everyone.\n\nCEO: Thank you for joining us today."
+        expected_response = GetTranscriptFromKeyDevIdResp(
+            transcript="Operator: Good morning, everyone.\n\nCEO: Thank you for joining us today."
         )
 
         tool = GetTranscriptFromKeyDevId(kfinance_client=mock_client)

--- a/kfinance/domains/line_items/line_item_tools.py
+++ b/kfinance/domains/line_items/line_item_tools.py
@@ -63,7 +63,7 @@ class GetFinancialLineItemFromIdentifiers(KfinanceTool):
         end_year: int | None = None,
         start_quarter: Literal[1, 2, 3, 4] | None = None,
         end_quarter: Literal[1, 2, 3, 4] | None = None,
-    ) -> dict:
+    ) -> GetFinancialLineItemFromIdentifiersResp:
         """Sample response:
 
         {
@@ -113,7 +113,6 @@ class GetFinancialLineItemFromIdentifiers(KfinanceTool):
                 most_recent_year_data = line_item_response.line_item[most_recent_year]
                 line_item_response.line_item = {most_recent_year: most_recent_year_data}
 
-        output_model = GetFinancialLineItemFromIdentifiersResp(
+        return GetFinancialLineItemFromIdentifiersResp(
             results=line_item_responses, errors=list(id_triple_resp.errors.values())
         )
-        return output_model.model_dump(mode="json")

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_models.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_models.py
@@ -1,6 +1,9 @@
 from datetime import date
+from decimal import Decimal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
+
+from kfinance.domains.companies.company_models import COMPANY_ID_PREFIX, CompanyIdAndName
 
 
 class MergerSummary(BaseModel):
@@ -16,6 +19,47 @@ class MergersResp(BaseModel):
 
 
 class AdvisorResp(BaseModel):
-    advisor_company_id: str
+    advisor_company_id: int
     advisor_company_name: str
     advisor_type_name: str | None
+
+    @field_serializer("advisor_company_id")
+    def serialize_with_prefix(self, company_id: int) -> str:
+        """Serialize the advisor_company_id with a prefix ("C_<company_id>").
+
+        Including the prefix allows us to distinguish tickers and company_ids.
+        """
+        return f"{COMPANY_ID_PREFIX}{company_id}"
+
+
+class MergerTimelineElement(BaseModel):
+    status: str
+    date: date
+
+
+class MergerParticipants(BaseModel):
+    target: CompanyIdAndName
+    buyers: list[CompanyIdAndName]
+    sellers: list[CompanyIdAndName]
+
+
+class MergerConsiderationDetail(BaseModel):
+    scenario: str | None = None
+    subtype: str | None = None
+    cash_or_cash_equivalent_per_target_share_unit: Decimal | None = None
+    number_of_target_shares_sought: Decimal | None = None
+    current_calculated_gross_value_of_consideration: Decimal | None = None
+
+
+class MergerConsideration(BaseModel):
+    currency_name: str | None = None
+    current_calculated_gross_total_transaction_value: Decimal | None = None
+    current_calculated_implied_equity_value: Decimal | None = None
+    current_calculated_implied_enterprise_value: Decimal | None = None
+    details: list[MergerConsiderationDetail]
+
+
+class MergerInfo(BaseModel):
+    timeline: list[MergerTimelineElement]
+    participants: MergerParticipants
+    consideration: MergerConsideration

--- a/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
@@ -8,13 +8,18 @@ from kfinance.client.tests.test_objects import (
     ordered,
 )
 from kfinance.conftest import SPGI_COMPANY_ID
-from kfinance.domains.companies.company_models import COMPANY_ID_PREFIX
+from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_models import (
+    AdvisorResp,
+    MergerInfo,
+)
 from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_tools import (
     GetAdvisorsForCompanyInTransactionFromIdentifier,
     GetAdvisorsForCompanyInTransactionFromIdentifierArgs,
+    GetAdvisorsForCompanyInTransactionFromIdentifierResp,
     GetMergerInfoFromTransactionId,
     GetMergerInfoFromTransactionIdArgs,
     GetMergersFromIdentifiers,
+    GetMergersFromIdentifiersResp,
 )
 from kfinance.integrations.tool_calling.tool_calling_models import ToolArgsWithIdentifiers
 
@@ -27,12 +32,14 @@ class TestGetMergersFromIdentifiers:
         THEN we get back the SPGI mergers and an error for the non-existent company"""
 
         merger_data = MERGERS_RESP.model_dump(mode="json")
-        expected_response = {
-            "results": {"SPGI": merger_data},
-            "errors": [
-                "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
-            ],
-        }
+        expected_response = GetMergersFromIdentifiersResp.model_validate(
+            {
+                "results": {"SPGI": merger_data},
+                "errors": [
+                    "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
+                ],
+            }
+        )
         requests_mock.get(
             url=f"https://kfinance.kensho.com/api/v1/mergers/{SPGI_COMPANY_ID}", json=merger_data
         )
@@ -51,13 +58,21 @@ class TestGetCompaniesAdvisingCompanyInTransactionFromIdentifier:
             "advisor_company_name": "Kensho Technologies, Inc.",
             "advisor_type_name": "Professional Mongo Enjoyer",
         }
-        api_response = {"advisors": [deepcopy(advisor_data)]}
-        expected_response = {"results": [deepcopy(advisor_data)]}
-        expected_response["results"][0]["advisor_company_id"] = f"{COMPANY_ID_PREFIX}251994106"
+        expected_response = GetAdvisorsForCompanyInTransactionFromIdentifierResp(
+            results=[
+                AdvisorResp(
+                    advisor_company_id=251994106,
+                    advisor_company_name="Kensho Technologies, Inc.",
+                    advisor_type_name="Professional Mongo Enjoyer",
+                )
+            ],
+            errors=[],
+        )
+
         transaction_id = 554979212
         requests_mock.get(
             url=f"https://kfinance.kensho.com/api/v1/merger/info/{transaction_id}/advisors/{SPGI_COMPANY_ID}",
-            json=api_response,
+            json={"advisors": [deepcopy(advisor_data)]},
         )
         tool = GetAdvisorsForCompanyInTransactionFromIdentifier(kfinance_client=mock_client)
         args = GetAdvisorsForCompanyInTransactionFromIdentifierArgs(
@@ -67,14 +82,14 @@ class TestGetCompaniesAdvisingCompanyInTransactionFromIdentifier:
         assert response == expected_response
 
     def test_get_companies_advising_company_in_transaction_from_bad_identifier(
-        self, requests_mock: Mocker, mock_client: Client
+        self, mock_client: Client
     ):
-        expected_response = {
-            "results": [],
-            "errors": [
+        expected_response = GetAdvisorsForCompanyInTransactionFromIdentifierResp(
+            results=[],
+            errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
-        }
+        )
         transaction_id = 554979212
         tool = GetAdvisorsForCompanyInTransactionFromIdentifier(kfinance_client=mock_client)
         args = GetAdvisorsForCompanyInTransactionFromIdentifierArgs(
@@ -86,30 +101,11 @@ class TestGetCompaniesAdvisingCompanyInTransactionFromIdentifier:
 
 class TestGetMergerInfoFromTransactionId:
     def test_get_merger_info_from_transaction_id(self, requests_mock: Mocker, mock_client: Client):
-        response_base = {
-            "timeline": [
-                {"status": "Announced", "date": "2000-09-12"},
-                {"status": "Closed", "date": "2000-09-12"},
-            ],
-            "participants": {},
-            "consideration": {
-                "currency_name": "US Dollar",
-                "current_calculated_gross_total_transaction_value": "51609375.000000",
-                "current_calculated_implied_equity_value": "51609375.000000",
-                "current_calculated_implied_enterprise_value": "51609375.000000",
-                "details": [
-                    {
-                        "scenario": "Stock Lump Sum",
-                        "subtype": "Common Equity",
-                        "cash_or_cash_equivalent_per_target_share_unit": None,
-                        "number_of_target_shares_sought": "1000000.000000",
-                        "current_calculated_gross_value_of_consideration": "51609375.000000",
-                    }
-                ],
-            },
-        }
-
-        participants_api_response = {
+        timeline_resp = [
+            {"status": "Announced", "date": "2000-09-12"},
+            {"status": "Closed", "date": "2000-09-12"},
+        ]
+        participants_resp = {
             "target": {"company_id": 31696, "company_name": "MongoMusic, Inc."},
             "buyers": [{"company_id": 21835, "company_name": "Microsoft Corporation"}],
             "sellers": [
@@ -117,33 +113,39 @@ class TestGetMergerInfoFromTransactionId:
                 {"company_id": 20087, "company_name": "Draper Richards, L.P."},
             ],
         }
-        api_response = deepcopy(response_base)
-        api_response["participants"] = participants_api_response
 
-        # Returned company IDs should be prefixed
-        expected_participants_tool_response = {
-            "target": {
-                "company_id": f"{COMPANY_ID_PREFIX}31696",
-                "company_name": "MongoMusic, Inc.",
-            },
-            "buyers": [
-                {"company_id": f"{COMPANY_ID_PREFIX}21835", "company_name": "Microsoft Corporation"}
-            ],
-            "sellers": [
-                {"company_id": f"{COMPANY_ID_PREFIX}18805", "company_name": "Angel Investors L.P."},
+        consideration_resp = {
+            "currency_name": "US Dollar",
+            "current_calculated_gross_total_transaction_value": "51609375.000000",
+            "current_calculated_implied_equity_value": "51609375.000000",
+            "current_calculated_implied_enterprise_value": "51609375.000000",
+            "details": [
                 {
-                    "company_id": f"{COMPANY_ID_PREFIX}20087",
-                    "company_name": "Draper Richards, L.P.",
-                },
+                    "scenario": "Stock Lump Sum",
+                    "subtype": "Common Equity",
+                    "cash_or_cash_equivalent_per_target_share_unit": None,
+                    "number_of_target_shares_sought": "1000000.000000",
+                    "current_calculated_gross_value_of_consideration": "51609375.000000",
+                }
             ],
         }
-        expected_response = deepcopy(response_base)
-        expected_response["participants"] = expected_participants_tool_response
+
+        expected_response = MergerInfo.model_validate(
+            {
+                "timeline": timeline_resp,
+                "participants": participants_resp,
+                "consideration": consideration_resp,
+            }
+        )
 
         transaction_id = 517414
         requests_mock.get(
             url=f"https://kfinance.kensho.com/api/v1/merger/info/{transaction_id}",
-            json=api_response,
+            json={
+                "timeline": timeline_resp,
+                "participants": participants_resp,
+                "consideration": consideration_resp,
+            },
         )
         tool = GetMergerInfoFromTransactionId(kfinance_client=mock_client)
         args = GetMergerInfoFromTransactionIdArgs(transaction_id=transaction_id)

--- a/kfinance/domains/prices/price_tools.py
+++ b/kfinance/domains/prices/price_tools.py
@@ -60,7 +60,7 @@ class GetPricesFromIdentifiers(KfinanceTool):
         end_date: date | None = None,
         periodicity: Periodicity = Periodicity.day,
         adjusted: bool = True,
-    ) -> dict:
+    ) -> GetPricesFromIdentifiersResp:
         """Sample Response:
 
         {
@@ -116,10 +116,9 @@ class GetPricesFromIdentifiers(KfinanceTool):
             for price_response in price_responses.values():
                 price_response.prices = price_response.prices[-1:]
 
-        output_model = GetPricesFromIdentifiersResp(
+        return GetPricesFromIdentifiersResp(
             results=price_responses, errors=list(id_triple_resp.errors.values())
         )
-        return output_model.model_dump(mode="json")
 
 
 class GetHistoryMetadataFromIdentifiersResp(ToolRespWithErrors):
@@ -136,7 +135,7 @@ class GetHistoryMetadataFromIdentifiers(KfinanceTool):
     args_schema: Type[BaseModel] = ToolArgsWithIdentifiers
     accepted_permissions: set[Permission] | None = None
 
-    def _run(self, identifiers: list[str]) -> dict:
+    def _run(self, identifiers: list[str]) -> GetHistoryMetadataFromIdentifiersResp:
         """Sample response:
 
         {
@@ -169,8 +168,6 @@ class GetHistoryMetadataFromIdentifiers(KfinanceTool):
         history_metadata_responses: dict[str, HistoryMetadataResp] = (
             process_tasks_in_thread_pool_executor(api_client=api_client, tasks=tasks)
         )
-        output_model = GetHistoryMetadataFromIdentifiersResp(
+        return GetHistoryMetadataFromIdentifiersResp(
             results=history_metadata_responses, errors=list(id_triple_resp.errors.values())
         )
-
-        return output_model.model_dump(mode="json")

--- a/kfinance/domains/prices/tests/test_price_tools.py
+++ b/kfinance/domains/prices/tests/test_price_tools.py
@@ -5,8 +5,10 @@ from kfinance.conftest import SPGI_TRADING_ITEM_ID
 from kfinance.domains.companies.company_models import COMPANY_ID_PREFIX
 from kfinance.domains.prices.price_tools import (
     GetHistoryMetadataFromIdentifiers,
+    GetHistoryMetadataFromIdentifiersResp,
     GetPricesFromIdentifiers,
     GetPricesFromIdentifiersArgs,
+    GetPricesFromIdentifiersResp,
 )
 from kfinance.integrations.tool_calling.tool_calling_models import ToolArgsWithIdentifiers
 
@@ -27,12 +29,14 @@ class TestGetHistoryMetadataFromIdentifiers:
             "instrument_type": "Equity",
             "symbol": "SPGI",
         }
-        expected_resp = {
-            "results": {"SPGI": metadata_resp},
-            "errors": [
-                "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
-            ],
-        }
+        expected_resp = GetHistoryMetadataFromIdentifiersResp.model_validate(
+            {
+                "results": {"SPGI": metadata_resp},
+                "errors": [
+                    "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
+                ],
+            }
+        )
 
         requests_mock.get(
             url=f"https://kfinance.kensho.com/api/v1/pricing/{SPGI_TRADING_ITEM_ID}/metadata",
@@ -80,33 +84,35 @@ class TestGetPricesFromIdentifiers:
             url=f"https://kfinance.kensho.com/api/v1/pricing/{SPGI_TRADING_ITEM_ID}/none/none/day/adjusted",
             json=self.prices_resp,
         )
-        expected_response = {
-            "results": {
-                "SPGI": {
-                    "prices": [
-                        {
-                            "date": "2024-04-11",
-                            "open": {"value": "424.26", "unit": "USD"},
-                            "high": {"value": "425.99", "unit": "USD"},
-                            "low": {"value": "422.04", "unit": "USD"},
-                            "close": {"value": "422.92", "unit": "USD"},
-                            "volume": {"value": "1129158", "unit": "Shares"},
-                        },
-                        {
-                            "date": "2024-04-12",
-                            "open": {"value": "419.23", "unit": "USD"},
-                            "high": {"value": "421.94", "unit": "USD"},
-                            "low": {"value": "416.45", "unit": "USD"},
-                            "close": {"value": "417.81", "unit": "USD"},
-                            "volume": {"value": "1182229", "unit": "Shares"},
-                        },
-                    ]
-                }
-            },
-            "errors": [
-                "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
-            ],
-        }
+        expected_response = GetPricesFromIdentifiersResp.model_validate(
+            {
+                "results": {
+                    "SPGI": {
+                        "prices": [
+                            {
+                                "date": "2024-04-11",
+                                "open": {"value": "424.26", "unit": "USD"},
+                                "high": {"value": "425.99", "unit": "USD"},
+                                "low": {"value": "422.04", "unit": "USD"},
+                                "close": {"value": "422.92", "unit": "USD"},
+                                "volume": {"value": "1129158", "unit": "Shares"},
+                            },
+                            {
+                                "date": "2024-04-12",
+                                "open": {"value": "419.23", "unit": "USD"},
+                                "high": {"value": "421.94", "unit": "USD"},
+                                "low": {"value": "416.45", "unit": "USD"},
+                                "close": {"value": "417.81", "unit": "USD"},
+                                "volume": {"value": "1182229", "unit": "Shares"},
+                            },
+                        ]
+                    }
+                },
+                "errors": [
+                    "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
+                ],
+            }
+        )
 
         tool = GetPricesFromIdentifiers(kfinance_client=mock_client)
         response = tool.run(
@@ -142,12 +148,14 @@ class TestGetPricesFromIdentifiers:
                 }
             ]
         }
-        expected_response = {
-            "results": {
-                "C_1": expected_single_company_response,
-                "C_2": expected_single_company_response,
-            },
-        }
+        expected_response = GetPricesFromIdentifiersResp.model_validate(
+            {
+                "results": {
+                    "C_1": expected_single_company_response,
+                    "C_2": expected_single_company_response,
+                },
+            }
+        )
         tool = GetPricesFromIdentifiers(kfinance_client=mock_client)
         response = tool.run(
             GetPricesFromIdentifiersArgs(

--- a/kfinance/domains/segments/segment_tools.py
+++ b/kfinance/domains/segments/segment_tools.py
@@ -43,7 +43,7 @@ class GetSegmentsFromIdentifiers(KfinanceTool):
         end_year: int | None = None,
         start_quarter: Literal[1, 2, 3, 4] | None = None,
         end_quarter: Literal[1, 2, 3, 4] | None = None,
-    ) -> dict:
+    ) -> GetSegmentsFromIdentifiersResp:
         """Sample Response:
 
         {
@@ -102,7 +102,6 @@ class GetSegmentsFromIdentifiers(KfinanceTool):
                 most_recent_year_data = segments_response.segments[most_recent_year]
                 segments_response.segments = {most_recent_year: most_recent_year_data}
 
-        output_model = GetSegmentsFromIdentifiersResp(
+        return GetSegmentsFromIdentifiersResp(
             results=segments_responses, errors=list(id_triple_resp.errors.values())
         )
-        return output_model.model_dump(mode="json")

--- a/kfinance/domains/segments/tests/test_segment_tools.py
+++ b/kfinance/domains/segments/tests/test_segment_tools.py
@@ -7,6 +7,7 @@ from kfinance.domains.segments.segment_models import SegmentType
 from kfinance.domains.segments.segment_tools import (
     GetSegmentsFromIdentifiers,
     GetSegmentsFromIdentifiersArgs,
+    GetSegmentsFromIdentifiersResp,
 )
 
 
@@ -43,12 +44,14 @@ class TestGetSegmentsFromIdentifier:
             json=self.segments_response,
         )
 
-        expected_response = {
-            "results": {"SPGI": self.segments_response},
-            "errors": [
-                "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
-            ],
-        }
+        expected_response = GetSegmentsFromIdentifiersResp.model_validate(
+            {
+                "results": {"SPGI": self.segments_response},
+                "errors": [
+                    "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
+                ],
+            }
+        )
 
         tool = GetSegmentsFromIdentifiers(kfinance_client=mock_client)
         args = GetSegmentsFromIdentifiersArgs(
@@ -65,12 +68,14 @@ class TestGetSegmentsFromIdentifier:
         """
 
         company_ids = [1, 2]
-        expected_response = {
-            "results": {
-                "C_1": {"segments": {"2021": self.segments_response["segments"]["2021"]}},
-                "C_2": {"segments": {"2021": self.segments_response["segments"]["2021"]}},
+        expected_response = GetSegmentsFromIdentifiersResp.model_validate(
+            {
+                "results": {
+                    "C_1": {"segments": {"2021": self.segments_response["segments"]["2021"]}},
+                    "C_2": {"segments": {"2021": self.segments_response["segments"]["2021"]}},
+                }
             }
-        }
+        )
 
         for company_id in company_ids:
             requests_mock.get(

--- a/kfinance/domains/statements/statement_tools.py
+++ b/kfinance/domains/statements/statement_tools.py
@@ -55,7 +55,7 @@ class GetFinancialStatementFromIdentifiers(KfinanceTool):
         end_year: int | None = None,
         start_quarter: Literal[1, 2, 3, 4] | None = None,
         end_quarter: Literal[1, 2, 3, 4] | None = None,
-    ) -> dict:
+    ) -> GetFinancialStatementFromIdentifiersResp:
         """Sample response:
 
         {
@@ -109,7 +109,6 @@ class GetFinancialStatementFromIdentifiers(KfinanceTool):
                 most_recent_year_data = statement_response.statements[most_recent_year]
                 statement_response.statements = {most_recent_year: most_recent_year_data}
 
-        output_model = GetFinancialStatementFromIdentifiersResp(
+        return GetFinancialStatementFromIdentifiersResp(
             results=statement_responses, errors=list(id_triple_resp.errors.values())
         )
-        return output_model.model_dump(mode="json")

--- a/kfinance/domains/statements/tests/test_statement_tools.py
+++ b/kfinance/domains/statements/tests/test_statement_tools.py
@@ -7,6 +7,7 @@ from kfinance.domains.statements.statement_models import StatementType
 from kfinance.domains.statements.statement_tools import (
     GetFinancialStatementFromIdentifiers,
     GetFinancialStatementFromIdentifiersArgs,
+    GetFinancialStatementFromIdentifiersResp,
 )
 
 
@@ -31,25 +32,27 @@ class TestGetFinancialStatementFromIdentifiers:
             url=f"https://kfinance.kensho.com/api/v1/statements/{SPGI_COMPANY_ID}/income_statement/none/none/none/none/none",
             json=self.statement_resp,
         )
-        expected_response = {
-            "results": {
-                "SPGI": {
-                    "statements": {
-                        "2020": {
-                            "Revenues": "7442000000.000000",
-                            "Total Revenues": "7442000000.000000",
-                        },
-                        "2021": {
-                            "Revenues": "8243000000.000000",
-                            "Total Revenues": "8243000000.000000",
-                        },
+        expected_response = GetFinancialStatementFromIdentifiersResp.model_validate(
+            {
+                "results": {
+                    "SPGI": {
+                        "statements": {
+                            "2020": {
+                                "Revenues": "7442000000.000000",
+                                "Total Revenues": "7442000000.000000",
+                            },
+                            "2021": {
+                                "Revenues": "8243000000.000000",
+                                "Total Revenues": "8243000000.000000",
+                            },
+                        }
                     }
-                }
-            },
-            "errors": [
-                "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
-            ],
-        }
+                },
+                "errors": [
+                    "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
+                ],
+            }
+        )
 
         tool = GetFinancialStatementFromIdentifiers(kfinance_client=mock_client)
         args = GetFinancialStatementFromIdentifiersArgs(
@@ -66,26 +69,28 @@ class TestGetFinancialStatementFromIdentifiers:
         """
 
         company_ids = [1, 2]
-        expected_response = {
-            "results": {
-                "C_1": {
-                    "statements": {
-                        "2021": {
-                            "Revenues": "8243000000.000000",
-                            "Total Revenues": "8243000000.000000",
+        expected_response = GetFinancialStatementFromIdentifiersResp.model_validate(
+            {
+                "results": {
+                    "C_1": {
+                        "statements": {
+                            "2021": {
+                                "Revenues": "8243000000.000000",
+                                "Total Revenues": "8243000000.000000",
+                            }
                         }
-                    }
-                },
-                "C_2": {
-                    "statements": {
-                        "2021": {
-                            "Revenues": "8243000000.000000",
-                            "Total Revenues": "8243000000.000000",
+                    },
+                    "C_2": {
+                        "statements": {
+                            "2021": {
+                                "Revenues": "8243000000.000000",
+                                "Total Revenues": "8243000000.000000",
+                            }
                         }
-                    }
-                },
+                    },
+                }
             }
-        }
+        )
 
         for company_id in company_ids:
             requests_mock.get(

--- a/kfinance/integrations/tool_calling/static_tools/get_n_quarters_ago.py
+++ b/kfinance/integrations/tool_calling/static_tools/get_n_quarters_ago.py
@@ -11,6 +11,11 @@ class GetNQuartersAgoArgs(BaseModel):
     n: int = Field(description="Number of quarters before the current quarter")
 
 
+class GetNQuartersAgoResp(BaseModel):
+    year: int
+    quarter: int
+
+
 class GetNQuartersAgo(KfinanceTool):
     name: str = "get_n_quarters_ago"
     description: str = (

--- a/kfinance/integrations/tool_calling/static_tools/tests/test_get_lastest.py
+++ b/kfinance/integrations/tool_calling/static_tools/tests/test_get_lastest.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import time_machine
 
 from kfinance.client.kfinance import Client
+from kfinance.client.models.date_and_period_models import LatestPeriods
 from kfinance.integrations.tool_calling.static_tools.get_latest import GetLatest, GetLatestArgs
 
 
@@ -15,16 +16,18 @@ class TestGetLatest:
         THEN we get back latest info
         """
 
-        expected_resp = {
-            "annual": {"latest_year": 2024},
-            "now": {
-                "current_date": "2025-01-01",
-                "current_month": 1,
-                "current_quarter": 1,
-                "current_year": 2025,
-            },
-            "quarterly": {"latest_quarter": 4, "latest_year": 2024},
-        }
+        expected_resp = LatestPeriods.model_validate(
+            {
+                "annual": {"latest_year": 2024},
+                "now": {
+                    "current_date": "2025-01-01",
+                    "current_month": 1,
+                    "current_quarter": 1,
+                    "current_year": 2025,
+                },
+                "quarterly": {"latest_quarter": 4, "latest_year": 2024},
+            }
+        )
         tool = GetLatest(kfinance_client=mock_client)
         resp = tool.run(GetLatestArgs().model_dump(mode="json"))
         assert resp == expected_resp

--- a/kfinance/integrations/tool_calling/static_tools/tests/test_get_n_quarters_ago.py
+++ b/kfinance/integrations/tool_calling/static_tools/tests/test_get_n_quarters_ago.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import time_machine
 
 from kfinance.client.kfinance import Client
+from kfinance.client.models.date_and_period_models import YearAndQuarter
 from kfinance.integrations.tool_calling.static_tools.get_n_quarters_ago import (
     GetNQuartersAgo,
     GetNQuartersAgoArgs,
@@ -18,7 +19,7 @@ class TestGetNQuartersAgo:
         THEN we get back 3 quarters ago
         """
 
-        expected_resp = {"quarter": 2, "year": 2024}
+        expected_resp = YearAndQuarter(year=2024, quarter=2)
         tool = GetNQuartersAgo(kfinance_client=mock_client)
         resp = tool.run(GetNQuartersAgoArgs(n=3).model_dump(mode="json"))
         assert resp == expected_resp

--- a/kfinance/integrations/tool_calling/tests/test_tool_calling_models.py
+++ b/kfinance/integrations/tool_calling/tests/test_tool_calling_models.py
@@ -7,7 +7,10 @@ from requests_mock import Mocker
 
 from kfinance.client.kfinance import Client
 from kfinance.conftest import SPGI_COMPANY_ID
-from kfinance.domains.companies.company_tools import GetInfoFromIdentifiers
+from kfinance.domains.companies.company_tools import (
+    GetInfoFromIdentifiers,
+    GetInfoFromIdentifiersResp,
+)
 from kfinance.integrations.tool_calling.tool_calling_models import ValidQuarter
 
 
@@ -27,7 +30,10 @@ class TestGetEndpointsFromToolCallsWithGrounding:
             "https://kfinance.kensho.com/api/v1/ids",
             "https://kfinance.kensho.com/api/v1/info/21719",
         ]
-        expected_resp = {"data": {"results": {"SPGI": resp_data}}, "endpoint_urls": resp_endpoint}
+        expected_resp = {
+            "data": GetInfoFromIdentifiersResp.model_validate({"results": {"SPGI": resp_data}}),
+            "endpoint_urls": resp_endpoint,
+        }
 
         requests_mock.get(
             url=f"https://kfinance.kensho.com/api/v1/info/{SPGI_COMPANY_ID}",


### PR DESCRIPTION
In order to create adapters for groundings, we need tool calls to return pydantic models rather than dict. That way, we can maintain a dict of pydantic response models to adapter functions. 

Nothing should change for the existing mcp and tool calling integrations. 

Tested: 
- tool calling with MCP
- openai langchain tool calling notebook (should be the same for gemini and anthropic)
- openai non-langchain tool calling notebook (should be the same for gemini and anthropic)