### PR TITLE
Fix validator for UnifiedIdTripleResponse

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# v3.2.7
+- Fix validator for UnifiedIdTripleResponse
+
 # v3.2.6
 - Return pydantic models from KfinanceTool._run
 

--- a/kfinance/domains/companies/company_models.py
+++ b/kfinance/domains/companies/company_models.py
@@ -84,14 +84,20 @@ class UnifiedIdTripleResponse(BaseModel):
 
 
         """
-        output: dict[str, dict] = dict(identifiers_to_id_triples=dict(), errors=dict())
+        # Separate successful and failed resolutions for kfinance api responses
         if isinstance(data, dict) and "data" in data:
+            output: dict[str, dict] = dict(identifiers_to_id_triples=dict(), errors=dict())
+
             for key, val in data["data"].items():
                 if "error" in val:
                     output["errors"][key] = val["error"]
                 else:
                     output["identifiers_to_id_triples"][key] = val
-        return output
+            return output
+        # In all other cases (e.g. UnifiedIdTripleResponse directly initialized),
+        # just return the data.
+        else:
+            return data
 
     def filter_out_companies_without_security_ids(self) -> None:
         """Filter out companies that don't have a security_id and add an error for them."""


### PR DESCRIPTION
Before this change, trying to initialize a `UnifiedIdTripleResponse` directly always returns `UnifiedIdTripleResponse(identifiers_to_id_triples={}, errors={})`, i.e. any passed id triples and errors are ignored.