### PR TITLE
Add company info to tool call results

### DIFF
--- a/example_notebooks/tool_calling/langchain/anthropic_langchain_tool_calling.ipynb
+++ b/example_notebooks/tool_calling/langchain/anthropic_langchain_tool_calling.ipynb
@@ -10,6 +10,9 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "# LangChain Tool Calling with Anthropic Claude\n",
     "**_Claude to retrieve data from the LLM-ready API using the kFinance python library!_**\n",
@@ -24,10 +27,7 @@
     "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/kensho-technologies/kfinance/blob/main/example_notebooks/tool_calling/langchain/anthropic_langchain_tool_calling.ipynb\"><img src=\"../../../images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
     "  </td>\n",
     "</table>"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "attachments": {},
@@ -144,7 +144,7 @@
     "        anthropic_api_key = SecretStr(\"\")  # replace with your own key\n",
     "        assert anthropic_api_key, \"Anthropic API key is empty! Make sure to enter your Anthropic API key above\"\n",
     "        llm = ChatAnthropic(model=\"claude-3-7-sonnet-20250219\",\n",
-    "                            api_key=anthropic_api_key)  # type: ignore[call-arg]\n",
+    "                            api_key=anthropic_api_key)\n",
     "\n",
     "        # Get the prompt to use - can be replaced with any prompt that includes variables \"agent_scratchpad\" and \"input\"!\n",
     "        # Prompt\n",
@@ -185,15 +185,15 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "name": "python"
   },
-  "orig_nbformat": 4,
-  "kernelspec": {
-   "name": "python3",
-   "language": "python",
-   "display_name": "Python 3 (ipykernel)"
-  }
+  "orig_nbformat": 4
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## v6.0.0
-- Updated tool call results to include company information
+- Update tool call results to include company information - in particular, 
+  company name, ticker, and country
 - Breaking changes:
   - The result type of identifier-based tool calls has been modified.
 

--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.0.0
+- Updated tool call results to include company information
+- Breaking changes:
+  - The result type of identifier-based tool calls has been modified.
+
 ## v5.1.4
 - Update tools to gracefully handle more errors
 

--- a/kfinance/conftest.py
+++ b/kfinance/conftest.py
@@ -6,15 +6,41 @@ from pytest_httpx import HTTPXMock
 from requests_mock import Mocker
 
 from kfinance.client.kfinance import Client
-from kfinance.domains.companies.company_models import IdentificationTriple
+from kfinance.domains.companies.company_models import IdentificationTripleWithCompanyInfo
 
 
 SPGI_COMPANY_ID = 21719
 SPGI_SECURITY_ID = 2629107
 SPGI_TRADING_ITEM_ID = 2629108
+SPGI_COMPANY_NAME = "S&P Global Inc."
+SPGI_TICKER = "NYSE:SPGI"
+SPGI_COUNTRY = "USA"
 
-SPGI_ID_TRIPLE = IdentificationTriple(
-    company_id=SPGI_COMPANY_ID, security_id=SPGI_SECURITY_ID, trading_item_id=SPGI_TRADING_ITEM_ID
+SPGI_ID_TRIPLE = IdentificationTripleWithCompanyInfo(
+    company_id=SPGI_COMPANY_ID,
+    security_id=SPGI_SECURITY_ID,
+    trading_item_id=SPGI_TRADING_ITEM_ID,
+    company_name=SPGI_COMPANY_NAME,
+    ticker=SPGI_TICKER,
+    country=SPGI_COUNTRY,
+)
+
+FAKE_COMPANY_1_ID_TRIPLE = IdentificationTripleWithCompanyInfo(
+    company_id=1,
+    security_id=1,
+    trading_item_id=1,
+    company_name="Company 1",
+    ticker="EXC:C1",
+    country="USA",
+)
+
+FAKE_COMPANY_2_ID_TRIPLE = IdentificationTripleWithCompanyInfo(
+    company_id=2,
+    security_id=2,
+    trading_item_id=2,
+    company_name="Company 2",
+    ticker="EXC:C2",
+    country="USA",
 )
 
 
@@ -71,7 +97,7 @@ def mock_client(requests_mock: Mocker) -> Client:
         additional_matcher=lambda req: req.json().get("identifiers") == ["C_1"],
         json={
             "data": {
-                "C_1": {"company_id": 1, "security_id": 1, "trading_item_id": 1},
+                "C_1": FAKE_COMPANY_1_ID_TRIPLE.model_dump(mode="json"),
             },
         },
     )
@@ -105,8 +131,8 @@ def mock_client(requests_mock: Mocker) -> Client:
         additional_matcher=lambda req: req.json().get("identifiers") == ["C_1", "C_2"],
         json={
             "data": {
-                "C_1": {"company_id": 1, "security_id": 1, "trading_item_id": 1},
-                "C_2": {"company_id": 2, "security_id": 2, "trading_item_id": 2},
+                "C_1": FAKE_COMPANY_1_ID_TRIPLE.model_dump(mode="json"),
+                "C_2": FAKE_COMPANY_2_ID_TRIPLE.model_dump(mode="json"),
             }
         },
     )
@@ -160,7 +186,14 @@ def httpx_client(httpx_mock: HTTPXMock) -> httpx.AsyncClient:
         json={
             "data": {
                 "SPGI": SPGI_ID_TRIPLE.model_dump(mode="json"),
-                "private_company": {"company_id": 1, "security_id": None, "trading_item_id": None},
+                "private_company": {
+                    "company_id": 1,
+                    "security_id": None,
+                    "trading_item_id": None,
+                    "company_name": "Private Company",
+                    "ticker": None,
+                    "country": "USA",
+                },
             }
         },
         is_optional=True,
@@ -171,8 +204,8 @@ def httpx_client(httpx_mock: HTTPXMock) -> httpx.AsyncClient:
         match_json={"identifiers": ["C_1", "C_2"]},
         json={
             "data": {
-                "C_1": {"company_id": 1, "security_id": 1, "trading_item_id": 1},
-                "C_2": {"company_id": 2, "security_id": 2, "trading_item_id": 2},
+                "C_1": FAKE_COMPANY_1_ID_TRIPLE.model_dump(mode="json"),
+                "C_2": FAKE_COMPANY_2_ID_TRIPLE.model_dump(mode="json"),
             }
         },
         is_optional=True,

--- a/kfinance/domains/business_relationships/business_relationship_tools.py
+++ b/kfinance/domains/business_relationships/business_relationship_tools.py
@@ -71,7 +71,7 @@ async def get_business_relationship_from_identifiers(
         'business_relationship': 'supplier',
         'results': {
             'SPGI': {
-                'company_name': 'SP Global Inc.',
+                'company_name': 'S&P Global Inc.',
                 'ticker': 'NYSE:SPGI',
                 'country': 'USA',
                 'data': {

--- a/kfinance/domains/business_relationships/business_relationship_tools.py
+++ b/kfinance/domains/business_relationships/business_relationship_tools.py
@@ -71,13 +71,18 @@ async def get_business_relationship_from_identifiers(
         'business_relationship': 'supplier',
         'results': {
             'SPGI': {
-                'current': [
-                    {'company_id': 'C_883103', 'company_name': 'CRISIL Limited'}
-                ],
-                'previous': [
-                    {'company_id': 'C_472898', 'company_name': 'Morgan Stanley'},
-                    {'company_id': 'C_8182358', 'company_name': 'Eloqua, Inc.'}
-                ]
+                'company_name': 'SP Global Inc.',
+                'ticker': 'NYSE:SPGI',
+                'country': 'USA',
+                'data': {
+                    'current': [
+                        {'company_id': 'C_883103', 'company_name': 'CRISIL Limited'}
+                    ],
+                    'previous': [
+                        {'company_id': 'C_472898', 'company_name': 'Morgan Stanley'},
+                        {'company_id': 'C_8182358', 'company_name': 'Eloqua, Inc.'}
+                    ]
+                }
             }
         },
         'errors': ['No identification triple found for the provided identifier: NON-EXISTENT of type: ticker']}

--- a/kfinance/domains/business_relationships/business_relationship_tools.py
+++ b/kfinance/domains/business_relationships/business_relationship_tools.py
@@ -113,7 +113,7 @@ async def get_business_relationship_from_identifiers(
     return GetBusinessRelationshipFromIdentifiersResp(
         business_relationship=business_relationship,
         identifier_results=results,
-        identifier_info=id_triple_resp,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
         errors=errors,
     )
 

--- a/kfinance/domains/business_relationships/business_relationship_tools.py
+++ b/kfinance/domains/business_relationships/business_relationship_tools.py
@@ -14,6 +14,7 @@ from kfinance.domains.business_relationships.business_relationship_models import
 from kfinance.integrations.tool_calling.tool_calling_models import (
     KfinanceTool,
     ToolArgsWithIdentifiers,
+    ToolRespWithIdInfoAndErrors,
 )
 
 
@@ -22,10 +23,8 @@ class GetBusinessRelationshipFromIdentifiersArgs(ToolArgsWithIdentifiers):
     business_relationship: BusinessRelationshipType
 
 
-class GetBusinessRelationshipFromIdentifiersResp(BaseModel):
+class GetBusinessRelationshipFromIdentifiersResp(ToolRespWithIdInfoAndErrors[RelationshipResponse]):
     business_relationship: BusinessRelationshipType
-    results: dict[str, RelationshipResponse]
-    errors: list[str]
 
 
 class GetBusinessRelationshipFromIdentifiers(KfinanceTool):
@@ -112,7 +111,10 @@ async def get_business_relationship_from_identifiers(
             results[task.result_key] = task.result
 
     return GetBusinessRelationshipFromIdentifiersResp(
-        business_relationship=business_relationship, results=results, errors=errors
+        business_relationship=business_relationship,
+        identifier_results=results,
+        identifier_info=id_triple_resp,
+        errors=errors,
     )
 
 

--- a/kfinance/domains/business_relationships/tests/test_business_relationship_tools.py
+++ b/kfinance/domains/business_relationships/tests/test_business_relationship_tools.py
@@ -51,7 +51,7 @@ class TestBusinessRelationships:
 
         expected_resp = GetBusinessRelationshipFromIdentifiersResp(
             business_relationship=BusinessRelationshipType.supplier,
-            results={"SPGI": self.expected_spgi_relationship_response},
+            identifier_results={"SPGI": self.expected_spgi_relationship_response},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],

--- a/kfinance/domains/business_relationships/tests/test_business_relationship_tools.py
+++ b/kfinance/domains/business_relationships/tests/test_business_relationship_tools.py
@@ -52,6 +52,7 @@ class TestBusinessRelationships:
         expected_resp = GetBusinessRelationshipFromIdentifiersResp(
             business_relationship=BusinessRelationshipType.supplier,
             identifier_results={"SPGI": self.expected_spgi_relationship_response},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],

--- a/kfinance/domains/capitalizations/capitalization_tools.py
+++ b/kfinance/domains/capitalizations/capitalization_tools.py
@@ -149,7 +149,7 @@ async def get_capitalizations_from_identifiers(
     return GetCapitalizationFromIdentifiersResp(
         capitalization=capitalization,
         identifier_results=results,
-        identifier_info=id_triple_resp,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
         errors=errors,
     )
 

--- a/kfinance/domains/capitalizations/capitalization_tools.py
+++ b/kfinance/domains/capitalizations/capitalization_tools.py
@@ -88,10 +88,17 @@ async def get_capitalizations_from_identifiers(
     {
         'capitalization': 'market_cap'
         'results': {
-            'SPGI': [
-                {'date': '2024-04-10', 'market_cap': {'value': '132766738270.00', 'unit': 'USD'}},
-                {'date': '2024-04-11', 'market_cap': {'value': '132416066761.00', 'unit': 'USD'}}
-            ]
+            'SPGI': {
+                'company_name': 'SP Global Inc.',
+                'ticker': 'NYSE:SPGI',
+                'country': 'USA',
+                'data': {
+                    'capitalizations': [
+                        {'date': '2024-04-10', 'market_cap': {'value': '132766738270.00', 'unit': 'USD'}},
+                        {'date': '2024-04-11', 'market_cap': {'value': '132416066761.00', 'unit': 'USD'}}
+                    ]
+                }
+            }
         },
         'errors': ['No identification triple found for the provided identifier: NON-EXISTENT of type: ticker']
     }

--- a/kfinance/domains/capitalizations/capitalization_tools.py
+++ b/kfinance/domains/capitalizations/capitalization_tools.py
@@ -89,7 +89,7 @@ async def get_capitalizations_from_identifiers(
         'capitalization': 'market_cap'
         'results': {
             'SPGI': {
-                'company_name': 'SP Global Inc.',
+                'company_name': 'S&P Global Inc.',
                 'ticker': 'NYSE:SPGI',
                 'country': 'USA',
                 'data': {

--- a/kfinance/domains/capitalizations/capitalization_tools.py
+++ b/kfinance/domains/capitalizations/capitalization_tools.py
@@ -12,7 +12,7 @@ from kfinance.domains.capitalizations.capitalization_models import Capitalizatio
 from kfinance.integrations.tool_calling.tool_calling_models import (
     KfinanceTool,
     ToolArgsWithIdentifiers,
-    ToolRespWithErrors,
+    ToolRespWithIdInfoAndErrors,
 )
 
 
@@ -29,9 +29,8 @@ class GetCapitalizationFromIdentifiersArgs(ToolArgsWithIdentifiers):
     )
 
 
-class GetCapitalizationFromIdentifiersResp(ToolRespWithErrors):
+class GetCapitalizationFromIdentifiersResp(ToolRespWithIdInfoAndErrors[Capitalizations]):
     capitalization: Capitalization
-    results: dict[str, Capitalizations]
 
 
 class GetCapitalizationFromIdentifiers(KfinanceTool):
@@ -148,7 +147,10 @@ async def get_capitalizations_from_identifiers(
             results[task.result_key] = capitalization_response
 
     return GetCapitalizationFromIdentifiersResp(
-        capitalization=capitalization, results=results, errors=errors
+        capitalization=capitalization,
+        identifier_results=results,
+        identifier_info=id_triple_resp,
+        errors=errors,
     )
 
 

--- a/kfinance/domains/capitalizations/tests/test_capitalization_tools.py
+++ b/kfinance/domains/capitalizations/tests/test_capitalization_tools.py
@@ -7,7 +7,12 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from kfinance.client.models.decimal_with_unit import Money, Shares
-from kfinance.conftest import SPGI_COMPANY_ID, SPGI_ID_TRIPLE
+from kfinance.conftest import (
+    FAKE_COMPANY_1_ID_TRIPLE,
+    FAKE_COMPANY_2_ID_TRIPLE,
+    SPGI_COMPANY_ID,
+    SPGI_ID_TRIPLE,
+)
 from kfinance.domains.capitalizations.capitalization_models import (
     Capitalization,
     Capitalizations,
@@ -99,6 +104,7 @@ class TestCapitalizations:
         expected_resp = GetCapitalizationFromIdentifiersResp(
             capitalization=Capitalization.market_cap,
             identifier_results={"SPGI": expected_spgi_resp},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -139,6 +145,7 @@ class TestCapitalizations:
         expected_resp = GetCapitalizationFromIdentifiersResp(
             capitalization=Capitalization.market_cap,
             identifier_results={"C_1": expected_company_resp, "C_2": expected_company_resp},
+            identifier_info={"C_1": FAKE_COMPANY_1_ID_TRIPLE, "C_2": FAKE_COMPANY_2_ID_TRIPLE},
         )
         resp = await get_capitalizations_from_identifiers(
             identifiers=["C_1", "C_2"],

--- a/kfinance/domains/capitalizations/tests/test_capitalization_tools.py
+++ b/kfinance/domains/capitalizations/tests/test_capitalization_tools.py
@@ -98,7 +98,7 @@ class TestCapitalizations:
             capitalization.shares_outstanding = None
         expected_resp = GetCapitalizationFromIdentifiersResp(
             capitalization=Capitalization.market_cap,
-            results={"SPGI": expected_spgi_resp},
+            identifier_results={"SPGI": expected_spgi_resp},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -138,7 +138,7 @@ class TestCapitalizations:
 
         expected_resp = GetCapitalizationFromIdentifiersResp(
             capitalization=Capitalization.market_cap,
-            results={"C_1": expected_company_resp, "C_2": expected_company_resp},
+            identifier_results={"C_1": expected_company_resp, "C_2": expected_company_resp},
         )
         resp = await get_capitalizations_from_identifiers(
             identifiers=["C_1", "C_2"],

--- a/kfinance/domains/companies/company_models.py
+++ b/kfinance/domains/companies/company_models.py
@@ -32,6 +32,11 @@ class IdentificationTriple(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
+class IdentificationTripleWithCompanyInfo(IdentificationTriple):
+    company_name: str
+    ticker: str | None
+
+
 class IdTripleResolutionError(BaseModel):
     """Error returned when an identifier cannot be resolved."""
 
@@ -45,9 +50,9 @@ class UnifiedIdTripleResponse(BaseModel):
     identifiers_to_id_triples (successful resolution) and errors (resolution failed).
     """
 
-    identifiers_to_id_triples: dict[str, IdentificationTriple] = Field(
+    identifiers_to_id_triples: dict[str, IdentificationTripleWithCompanyInfo] = Field(
         description="A mapping of all identifiers that could successfully be resolved"
-        "to the corresponding identification triples."
+        "to the corresponding identification triples with company info."
     )
     errors: dict[str, str] = Field(
         description="A mapping of all identifiers that could not be resolved or don't have "

--- a/kfinance/domains/companies/company_models.py
+++ b/kfinance/domains/companies/company_models.py
@@ -34,7 +34,8 @@ class IdentificationTriple(BaseModel):
 
 class IdentificationTripleWithCompanyInfo(IdentificationTriple):
     company_name: str
-    ticker: str | None
+    ticker: str | None = Field(description="Private companies do not have a ticker.")
+    country: str | None
 
 
 class IdTripleResolutionError(BaseModel):

--- a/kfinance/domains/companies/company_tools.py
+++ b/kfinance/domains/companies/company_tools.py
@@ -15,12 +15,12 @@ from kfinance.domains.companies.company_models import (
 from kfinance.integrations.tool_calling.tool_calling_models import (
     KfinanceTool,
     ToolArgsWithIdentifiers,
-    ToolRespWithErrors,
+    ToolRespWithIdInfoAndErrors,
 )
 
 
-class GetInfoFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, dict]
+class GetInfoFromIdentifiersResp(ToolRespWithIdInfoAndErrors[dict]):
+    pass
 
 
 class GetInfoFromIdentifiers(KfinanceTool):
@@ -48,8 +48,8 @@ class GetInfoFromIdentifiers(KfinanceTool):
         )
 
 
-class GetCompanyOtherNamesFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, CompanyOtherNames]
+class GetCompanyOtherNamesFromIdentifiersResp(ToolRespWithIdInfoAndErrors[CompanyOtherNames]):
+    pass
 
 
 class GetCompanyOtherNamesFromIdentifiers(KfinanceTool):
@@ -80,8 +80,8 @@ class GetCompanyOtherNamesFromIdentifiers(KfinanceTool):
         )
 
 
-class GetCompanySummaryFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, str]
+class GetCompanySummaryFromIdentifiersResp(ToolRespWithIdInfoAndErrors[str]):
+    pass
 
 
 class GetCompanySummaryFromIdentifiers(KfinanceTool):
@@ -113,8 +113,8 @@ class GetCompanySummaryFromIdentifiers(KfinanceTool):
         )
 
 
-class GetCompanyDescriptionFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, str]
+class GetCompanyDescriptionFromIdentifiersResp(ToolRespWithIdInfoAndErrors[str]):
+    pass
 
 
 class GetCompanyDescriptionFromIdentifiers(KfinanceTool):
@@ -205,7 +205,9 @@ async def get_info_from_identifiers(
     for identifier, id_triple in id_triple_resp.identifiers_to_id_triples.items():
         results[identifier]["company_id"] = prefix_company_id(id_triple.company_id)
 
-    resp_model = GetInfoFromIdentifiersResp(results=results, errors=errors)
+    resp_model = GetInfoFromIdentifiersResp(
+        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+    )
     return resp_model
 
 
@@ -252,7 +254,9 @@ async def get_company_other_names_from_identifiers(
         else:
             results[task.result_key] = task.result
 
-    return GetCompanyOtherNamesFromIdentifiersResp(results=results, errors=errors)
+    return GetCompanyOtherNamesFromIdentifiersResp(
+        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+    )
 
 
 async def fetch_company_other_names_from_company_id(
@@ -323,9 +327,13 @@ async def get_company_summary_or_description_from_identifiers(
                 results[task.result_key] = result
 
     if summary_or_description == "summary":
-        return GetCompanySummaryFromIdentifiersResp(results=results, errors=errors)
+        return GetCompanySummaryFromIdentifiersResp(
+            identifier_results=results, identifier_info=id_triple_resp, errors=errors
+        )
     else:
-        return GetCompanyDescriptionFromIdentifiersResp(results=results, errors=errors)
+        return GetCompanyDescriptionFromIdentifiersResp(
+            identifier_results=results, identifier_info=id_triple_resp, errors=errors
+        )
 
 
 async def fetch_company_summary_and_description_from_company_id(

--- a/kfinance/domains/companies/company_tools.py
+++ b/kfinance/domains/companies/company_tools.py
@@ -156,20 +156,25 @@ async def get_info_from_identifiers(
 
         {   "results": {
                 "SPGI": {
-                    "name": "S&P Global Inc.",
-                    "status": "Operating",
-                    "type": "Public Company",
-                    "simple_industry": "Capital Markets",
-                    "number_of_employees": "42350.0000",
-                    "founding_date": "1860-01-01",
-                    "webpage": "www.spglobal.com",
-                    "address": "55 Water Street",
-                    "city": "New York",
-                    "zip_code": "10041-0001",
-                    "state": "New York",
-                    "country": "United States",
-                    "iso_country": "USA",
-                    "company_id": "C_21719"
+                    "company_name": "SP Global Inc.",
+                    "ticker": "NYSE:SPGI",
+                    "country": "USA",
+                    "data: {
+                        "name": "S&P Global Inc.",
+                        "status": "Operating",
+                        "type": "Public Company",
+                        "simple_industry": "Capital Markets",
+                        "number_of_employees": "42350.0000",
+                        "founding_date": "1860-01-01",
+                        "webpage": "www.spglobal.com",
+                        "address": "55 Water Street",
+                        "city": "New York",
+                        "zip_code": "10041-0001",
+                        "state": "New York",
+                        "country": "United States",
+                        "iso_country": "USA",
+                        "company_id": "C_21719"
+                    }
                 }
             },
             "errors": [['No identification triple found for the provided identifier: NON-EXISTENT of type: ticker']

--- a/kfinance/domains/companies/company_tools.py
+++ b/kfinance/domains/companies/company_tools.py
@@ -15,12 +15,16 @@ from kfinance.domains.companies.company_models import (
 from kfinance.integrations.tool_calling.tool_calling_models import (
     KfinanceTool,
     ToolArgsWithIdentifiers,
+    ToolRespWithErrors,
     ToolRespWithIdInfoAndErrors,
 )
 
 
-class GetInfoFromIdentifiersResp(ToolRespWithIdInfoAndErrors[dict]):
-    pass
+# We use ToolRespWithErrors here since company information is already
+# included in the results, and we don't want to duplicate it by using
+# ToolRespWithIdInfoAndErrors.
+class GetInfoFromIdentifiersResp(ToolRespWithErrors):
+    results: dict[str, dict]
 
 
 class GetInfoFromIdentifiers(KfinanceTool):
@@ -156,25 +160,21 @@ async def get_info_from_identifiers(
 
         {   "results": {
                 "SPGI": {
-                    "company_name": "SP Global Inc.",
-                    "ticker": "NYSE:SPGI",
-                    "country": "USA",
-                    "data: {
-                        "name": "S&P Global Inc.",
-                        "status": "Operating",
-                        "type": "Public Company",
-                        "simple_industry": "Capital Markets",
-                        "number_of_employees": "42350.0000",
-                        "founding_date": "1860-01-01",
-                        "webpage": "www.spglobal.com",
-                        "address": "55 Water Street",
-                        "city": "New York",
-                        "zip_code": "10041-0001",
-                        "state": "New York",
-                        "country": "United States",
-                        "iso_country": "USA",
-                        "company_id": "C_21719"
-                    }
+                    "name": "S&P Global Inc.",
+                    "status": "Operating",
+                    "type": "Public Company",
+                    "simple_industry": "Capital Markets",
+                    "number_of_employees": "42350.0000",
+                    "founding_date": "1860-01-01",
+                    "webpage": "www.spglobal.com",
+                    "address": "55 Water Street",
+                    "city": "New York",
+                    "zip_code": "10041-0001",
+                    "state": "New York",
+                    "country": "United States",
+                    "iso_country": "USA",
+                    "company_id": "C_21719",
+                    "ticker": "NYSE:SPGI"
                 }
             },
             "errors": [['No identification triple found for the provided identifier: NON-EXISTENT of type: ticker']
@@ -209,10 +209,11 @@ async def get_info_from_identifiers(
 
     for identifier, id_triple in id_triple_resp.identifiers_to_id_triples.items():
         results[identifier]["company_id"] = prefix_company_id(id_triple.company_id)
+        if id_triple.ticker:
+            results[identifier]["ticker"] = id_triple.ticker
 
     resp_model = GetInfoFromIdentifiersResp(
-        identifier_results=results,
-        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        results=results,
         errors=errors,
     )
     return resp_model

--- a/kfinance/domains/companies/company_tools.py
+++ b/kfinance/domains/companies/company_tools.py
@@ -206,7 +206,9 @@ async def get_info_from_identifiers(
         results[identifier]["company_id"] = prefix_company_id(id_triple.company_id)
 
     resp_model = GetInfoFromIdentifiersResp(
-        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+        identifier_results=results,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )
     return resp_model
 
@@ -255,7 +257,9 @@ async def get_company_other_names_from_identifiers(
             results[task.result_key] = task.result
 
     return GetCompanyOtherNamesFromIdentifiersResp(
-        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+        identifier_results=results,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )
 
 
@@ -328,11 +332,15 @@ async def get_company_summary_or_description_from_identifiers(
 
     if summary_or_description == "summary":
         return GetCompanySummaryFromIdentifiersResp(
-            identifier_results=results, identifier_info=id_triple_resp, errors=errors
+            identifier_results=results,
+            identifier_info=id_triple_resp.identifiers_to_id_triples,
+            errors=errors,
         )
     else:
         return GetCompanyDescriptionFromIdentifiersResp(
-            identifier_results=results, identifier_info=id_triple_resp, errors=errors
+            identifier_results=results,
+            identifier_info=id_triple_resp.identifiers_to_id_triples,
+            errors=errors,
         )
 
 

--- a/kfinance/domains/companies/tests/test_company_tools.py
+++ b/kfinance/domains/companies/tests/test_company_tools.py
@@ -62,6 +62,7 @@ class TestGetCompanyInfo:
 
         expected_resp = GetInfoFromIdentifiersResp(
             identifier_results={"SPGI": self.spgi_info_resp},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -138,7 +139,8 @@ class TestGetCompanyOtherNames:
         """
 
         expected_resp = GetCompanyOtherNamesFromIdentifiersResp(
-            results={"SPGI": self.spgi_other_names_model},
+            identifier_results={"SPGI": self.spgi_other_names_model},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -197,7 +199,8 @@ class TestGetCompanySummaryAndDescription:
         """
 
         expected_resp = GetCompanySummaryFromIdentifiersResp(
-            results={"SPGI": self.spgi_descriptions_model.summary},
+            identifier_results={"SPGI": self.spgi_descriptions_model.summary},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -221,7 +224,8 @@ class TestGetCompanySummaryAndDescription:
         """
 
         expected_resp = GetCompanyDescriptionFromIdentifiersResp(
-            results={"SPGI": self.spgi_descriptions_model.description},
+            identifier_results={"SPGI": self.spgi_descriptions_model.description},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],

--- a/kfinance/domains/companies/tests/test_company_tools.py
+++ b/kfinance/domains/companies/tests/test_company_tools.py
@@ -61,12 +61,14 @@ class TestGetCompanyInfo:
         """
 
         expected_resp = GetInfoFromIdentifiersResp(
-            results={"SPGI": self.spgi_info_resp},
+            identifier_results={"SPGI": self.spgi_info_resp},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
         )
-        expected_resp.results["SPGI"]["company_id"] = prefix_company_id(SPGI_ID_TRIPLE.company_id)
+        expected_resp.identifier_results["SPGI"]["company_id"] = prefix_company_id(
+            SPGI_ID_TRIPLE.company_id
+        )
 
         resp = await get_info_from_identifiers(
             identifiers=["SPGI", "non-existent"],

--- a/kfinance/domains/companies/tests/test_company_tools.py
+++ b/kfinance/domains/companies/tests/test_company_tools.py
@@ -2,7 +2,7 @@ import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
-from kfinance.conftest import SPGI_COMPANY_ID, SPGI_ID_TRIPLE
+from kfinance.conftest import SPGI_COMPANY_ID, SPGI_ID_TRIPLE, SPGI_TICKER
 from kfinance.domains.companies.company_models import (
     CompanyDescriptions,
     CompanyOtherNames,
@@ -61,15 +61,13 @@ class TestGetCompanyInfo:
         """
 
         expected_resp = GetInfoFromIdentifiersResp(
-            identifier_results={"SPGI": self.spgi_info_resp},
-            identifier_info={"SPGI": SPGI_ID_TRIPLE},
+            results={"SPGI": self.spgi_info_resp},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
         )
-        expected_resp.identifier_results["SPGI"]["company_id"] = prefix_company_id(
-            SPGI_ID_TRIPLE.company_id
-        )
+        expected_resp.results["SPGI"]["company_id"] = prefix_company_id(SPGI_ID_TRIPLE.company_id)
+        expected_resp.results["SPGI"]["ticker"] = SPGI_TICKER
 
         resp = await get_info_from_identifiers(
             identifiers=["SPGI", "non-existent"],

--- a/kfinance/domains/competitors/competitor_tools.py
+++ b/kfinance/domains/competitors/competitor_tools.py
@@ -102,7 +102,9 @@ async def get_competitors_from_identifiers(
             results[task.result_key] = task.result
 
     resp_model = GetCompetitorsFromIdentifiersResp(
-        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+        identifier_results=results,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )
     return resp_model
 

--- a/kfinance/domains/competitors/competitor_tools.py
+++ b/kfinance/domains/competitors/competitor_tools.py
@@ -66,8 +66,15 @@ async def get_competitors_from_identifiers(
     {
         "results": {
             "SPGI": {
-                {'company_id': "C_35352", 'company_name': 'The Descartes Systems Group Inc.'},
-                {'company_id': "C_4003514", 'company_name': 'London Stock Exchange Group plc'}
+                'company_name': 'SP Global Inc.',
+                'ticker': 'NYSE:SPGI',
+                'country': 'USA',
+                'data': {
+                    'competitors': [
+                        {'company_id': "C_35352", 'company_name': 'The Descartes Systems Group Inc.'},
+                        {'company_id': "C_4003514", 'company_name': 'London Stock Exchange Group plc'}
+                    ]
+                }
             }
         },
         'errors': ['No identification triple found for the provided identifier: NON-EXISTENT of type: ticker']

--- a/kfinance/domains/competitors/competitor_tools.py
+++ b/kfinance/domains/competitors/competitor_tools.py
@@ -10,7 +10,7 @@ from kfinance.domains.competitors.competitor_models import CompetitorResponse, C
 from kfinance.integrations.tool_calling.tool_calling_models import (
     KfinanceTool,
     ToolArgsWithIdentifiers,
-    ToolRespWithErrors,
+    ToolRespWithIdInfoAndErrors,
 )
 
 
@@ -19,8 +19,8 @@ class GetCompetitorsFromIdentifiersArgs(ToolArgsWithIdentifiers):
     competitor_source: CompetitorSource
 
 
-class GetCompetitorsFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, CompetitorResponse]
+class GetCompetitorsFromIdentifiersResp(ToolRespWithIdInfoAndErrors[CompetitorResponse]):
+    pass
 
 
 class GetCompetitorsFromIdentifiers(KfinanceTool):
@@ -101,7 +101,9 @@ async def get_competitors_from_identifiers(
         else:
             results[task.result_key] = task.result
 
-    resp_model = GetCompetitorsFromIdentifiersResp(results=results, errors=errors)
+    resp_model = GetCompetitorsFromIdentifiersResp(
+        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+    )
     return resp_model
 
 

--- a/kfinance/domains/competitors/competitor_tools.py
+++ b/kfinance/domains/competitors/competitor_tools.py
@@ -66,7 +66,7 @@ async def get_competitors_from_identifiers(
     {
         "results": {
             "SPGI": {
-                'company_name': 'SP Global Inc.',
+                'company_name': 'S&P Global Inc.',
                 'ticker': 'NYSE:SPGI',
                 'country': 'USA',
                 'data': {

--- a/kfinance/domains/competitors/tests/test_competitor_tools.py
+++ b/kfinance/domains/competitors/tests/test_competitor_tools.py
@@ -65,6 +65,7 @@ class TestCompetitors:
 
         expected_resp = GetCompetitorsFromIdentifiersResp(
             identifier_results={"SPGI": self.expected_spgi_competitors_response},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],

--- a/kfinance/domains/competitors/tests/test_competitor_tools.py
+++ b/kfinance/domains/competitors/tests/test_competitor_tools.py
@@ -64,7 +64,7 @@ class TestCompetitors:
         """
 
         expected_resp = GetCompetitorsFromIdentifiersResp(
-            results={"SPGI": self.expected_spgi_competitors_response},
+            identifier_results={"SPGI": self.expected_spgi_competitors_response},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],

--- a/kfinance/domains/cusip_and_isin/cusip_and_isin_tools.py
+++ b/kfinance/domains/cusip_and_isin/cusip_and_isin_tools.py
@@ -116,7 +116,9 @@ async def get_cusip_or_isin_from_identifiers(
             results[task.result_key] = task.result
 
     return GetCusipOrIsinFromIdentifiersResp(
-        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+        identifier_results=results,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )
 
 

--- a/kfinance/domains/cusip_and_isin/cusip_and_isin_tools.py
+++ b/kfinance/domains/cusip_and_isin/cusip_and_isin_tools.py
@@ -82,7 +82,14 @@ async def get_cusip_or_isin_from_identifiers(
     Sample response:
 
         {
-            'results': {'SPGI': '78409V104'},
+            'results': {
+                'SPGI': {
+                    'company_name': 'SP Global Inc.',
+                    'ticker': 'NYSE:SPGI',
+                    'country': 'USA',
+                    'data': '78409V104'
+                }
+            },
             'errors': ['Kensho is a private company without a security_id.']
         }
     """

--- a/kfinance/domains/cusip_and_isin/cusip_and_isin_tools.py
+++ b/kfinance/domains/cusip_and_isin/cusip_and_isin_tools.py
@@ -84,7 +84,7 @@ async def get_cusip_or_isin_from_identifiers(
         {
             'results': {
                 'SPGI': {
-                    'company_name': 'SP Global Inc.',
+                    'company_name': 'S&P Global Inc.',
                     'ticker': 'NYSE:SPGI',
                     'country': 'USA',
                     'data': '78409V104'

--- a/kfinance/domains/cusip_and_isin/cusip_and_isin_tools.py
+++ b/kfinance/domains/cusip_and_isin/cusip_and_isin_tools.py
@@ -10,14 +10,14 @@ from kfinance.client.permission_models import Permission
 from kfinance.integrations.tool_calling.tool_calling_models import (
     KfinanceTool,
     ToolArgsWithIdentifiers,
-    ToolRespWithErrors,
+    ToolRespWithIdInfoAndErrors,
 )
 
 
-class GetCusipOrIsinFromIdentifiersResp(ToolRespWithErrors):
+class GetCusipOrIsinFromIdentifiersResp(ToolRespWithIdInfoAndErrors[str]):
     """Both cusip and isin return a mapping from identifier to str (isin or cusip)."""
 
-    results: dict[str, str]
+    pass
 
 
 class GetCusipFromIdentifiers(KfinanceTool):
@@ -115,7 +115,9 @@ async def get_cusip_or_isin_from_identifiers(
         else:
             results[task.result_key] = task.result
 
-    return GetCusipOrIsinFromIdentifiersResp(results=results, errors=errors)
+    return GetCusipOrIsinFromIdentifiersResp(
+        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+    )
 
 
 async def fetch_cusip_or_isin_from_security_id(

--- a/kfinance/domains/cusip_and_isin/tests/test_cusip_and_isin_tools.py
+++ b/kfinance/domains/cusip_and_isin/tests/test_cusip_and_isin_tools.py
@@ -73,7 +73,7 @@ class TestCusipAndIsin:
         """
 
         expected_resp = GetCusipOrIsinFromIdentifiersResp(
-            results={"SPGI": expected_response},
+            identifier_results={"SPGI": expected_response},
             errors=["private_company is a private company without a security_id."],
         )
 

--- a/kfinance/domains/cusip_and_isin/tests/test_cusip_and_isin_tools.py
+++ b/kfinance/domains/cusip_and_isin/tests/test_cusip_and_isin_tools.py
@@ -4,7 +4,7 @@ import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
-from kfinance.conftest import SPGI_ID_TRIPLE
+from kfinance.conftest import SPGI_ID_TRIPLE, SPGI_SECURITY_ID
 from kfinance.domains.cusip_and_isin.cusip_and_isin_tools import (
     GetCusipOrIsinFromIdentifiersResp,
     fetch_cusip_or_isin_from_security_id,
@@ -50,7 +50,7 @@ class TestCusipAndIsin:
         """
 
         resp = await fetch_cusip_or_isin_from_security_id(
-            security_id=SPGI_ID_TRIPLE.security_id,
+            security_id=SPGI_SECURITY_ID,
             cusip_or_isin=cusip_or_isin,
             httpx_client=httpx_client,
         )
@@ -74,6 +74,7 @@ class TestCusipAndIsin:
 
         expected_resp = GetCusipOrIsinFromIdentifiersResp(
             identifier_results={"SPGI": expected_response},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=["private_company is a private company without a security_id."],
         )
 

--- a/kfinance/domains/earnings/earning_tools.py
+++ b/kfinance/domains/earnings/earning_tools.py
@@ -184,7 +184,9 @@ async def get_earnings_from_identifiers(
             results[task.result_key] = task.result
 
     return GetEarningsFromIdentifiersResp(
-        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+        identifier_results=results,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )
 
 

--- a/kfinance/domains/earnings/earning_tools.py
+++ b/kfinance/domains/earnings/earning_tools.py
@@ -11,7 +11,7 @@ from kfinance.domains.earnings.earning_models import EarningsCall, EarningsCallR
 from kfinance.integrations.tool_calling.tool_calling_models import (
     KfinanceTool,
     ToolArgsWithIdentifiers,
-    ToolRespWithErrors,
+    ToolRespWithIdInfoAndErrors,
 )
 
 
@@ -47,12 +47,12 @@ class GetTranscriptFromKeyDevId(KfinanceTool):
         )
 
 
-class GetEarningsFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, EarningsCallResp]
+class GetEarningsFromIdentifiersResp(ToolRespWithIdInfoAndErrors[EarningsCallResp]):
+    pass
 
 
-class GetNextOrLatestEarningsFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, EarningsCall]
+class GetNextOrLatestEarningsFromIdentifiersResp(ToolRespWithIdInfoAndErrors[EarningsCall]):
+    pass
 
 
 class GetEarningsFromIdentifiers(KfinanceTool):
@@ -183,7 +183,9 @@ async def get_earnings_from_identifiers(
         else:
             results[task.result_key] = task.result
 
-    return GetEarningsFromIdentifiersResp(results=results, errors=errors)
+    return GetEarningsFromIdentifiersResp(
+        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+    )
 
 
 async def get_latest_earnings_from_identifiers(
@@ -195,11 +197,13 @@ async def get_latest_earnings_from_identifiers(
         identifiers=identifiers,
         httpx_client=httpx_client,
     )
-    output_model = GetNextOrLatestEarningsFromIdentifiersResp(results=dict(), errors=list())
-    for identifier, earnings in earnings_responses.results.items():
+    output_model = GetNextOrLatestEarningsFromIdentifiersResp(
+        identifier_results=dict(), identifier_info=earnings_responses.identifier_info, errors=list()
+    )
+    for identifier, earnings in earnings_responses.identifier_results.items():
         most_recent_earnings = earnings.most_recent_earnings
         if most_recent_earnings:
-            output_model.results[identifier] = most_recent_earnings
+            output_model.identifier_results[identifier] = most_recent_earnings
         else:
             output_model.errors.append(f"No latest earnings available for {identifier}.")
     # Add errors from the earnings fetch
@@ -216,11 +220,13 @@ async def get_next_earnings_from_identifiers(
         identifiers=identifiers,
         httpx_client=httpx_client,
     )
-    output_model = GetNextOrLatestEarningsFromIdentifiersResp(results=dict(), errors=list())
-    for identifier, earnings in earnings_responses.results.items():
+    output_model = GetNextOrLatestEarningsFromIdentifiersResp(
+        identifier_results=dict(), identifier_info=earnings_responses.identifier_info, errors=list()
+    )
+    for identifier, earnings in earnings_responses.identifier_results.items():
         next_earnings = earnings.next_earnings
         if next_earnings:
-            output_model.results[identifier] = next_earnings
+            output_model.identifier_results[identifier] = next_earnings
         else:
             output_model.errors.append(f"No next earnings available for {identifier}.")
     # Add errors from the earnings fetch

--- a/kfinance/domains/earnings/tests/test_earnings_tools.py
+++ b/kfinance/domains/earnings/tests/test_earnings_tools.py
@@ -93,7 +93,7 @@ class TestEarnings:
         """
 
         expected_resp = GetEarningsFromIdentifiersResp(
-            results={
+            identifier_results={
                 "SPGI": EarningsCallResp.model_validate(
                     {
                         "earnings": [
@@ -141,7 +141,7 @@ class TestEarnings:
         )
 
         # Verify SPGI latest earnings logic
-        spgi_earnings = resp.results["SPGI"]
+        spgi_earnings = resp.identifier_results["SPGI"]
         latest_earnings = spgi_earnings.most_recent_earnings
         assert latest_earnings is not None
         assert latest_earnings.name == "SPGI Q1 2025 Earnings Call"
@@ -165,7 +165,7 @@ class TestEarnings:
         )
 
         # Verify SPGI next earnings logic
-        spgi_earnings = resp.results["SPGI"]
+        spgi_earnings = resp.identifier_results["SPGI"]
         next_earnings = spgi_earnings.next_earnings
         assert next_earnings is not None
         assert next_earnings.name == "SPGI Q1 2025 Earnings Call"

--- a/kfinance/domains/earnings/tests/test_earnings_tools.py
+++ b/kfinance/domains/earnings/tests/test_earnings_tools.py
@@ -111,6 +111,7 @@ class TestEarnings:
                     }
                 )
             },
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],

--- a/kfinance/domains/estimates/estimates_tools.py
+++ b/kfinance/domains/estimates/estimates_tools.py
@@ -230,7 +230,9 @@ async def get_estimates_from_identifiers(
                 errors.append(error_msg)
 
     resp_model = GetEstimatesFromIdentifiersResp(
-        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+        identifier_results=results,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )
 
     # Add explanatory notes
@@ -320,7 +322,9 @@ async def get_consensus_target_price_from_identifiers(
                 errors.append(error_msg)
 
     return GetConsensusTargetPriceFromIdentifiersResp(
-        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+        identifier_results=results,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )
 
 
@@ -372,7 +376,9 @@ async def get_analyst_recommendations_from_identifiers(
                 errors.append(error_msg)
 
     return GetAnalystRecommendationsFromIdentifiersResp(
-        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+        identifier_results=results,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )
 
 

--- a/kfinance/domains/estimates/estimates_tools.py
+++ b/kfinance/domains/estimates/estimates_tools.py
@@ -27,7 +27,7 @@ from kfinance.domains.line_items.response_notes import (
 from kfinance.integrations.tool_calling.tool_calling_models import (
     KfinanceTool,
     ToolArgsWithIdentifiers,
-    ToolRespWithErrors,
+    ToolRespWithIdInfoAndErrors,
     ValidQuarter,
 )
 
@@ -61,8 +61,7 @@ class GetEstimatesFromIdentifiersArgs(ToolArgsWithIdentifiers):
     )
 
 
-class GetEstimatesFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, Estimates]  # identifier -> response
+class GetEstimatesFromIdentifiersResp(ToolRespWithIdInfoAndErrors[Estimates]):
     notes: list[str] = Field(default_factory=list)
 
 
@@ -131,8 +130,8 @@ class GetGuidanceFromIdentifiers(GetEstimatesFromIdentifiers):
         return EstimateType.guidance
 
 
-class GetConsensusTargetPriceFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, ConsensusTargetPrice]
+class GetConsensusTargetPriceFromIdentifiersResp(ToolRespWithIdInfoAndErrors[ConsensusTargetPrice]):
+    pass
 
 
 class GetConsensusTargetPriceFromIdentifiers(KfinanceTool):
@@ -153,8 +152,10 @@ class GetConsensusTargetPriceFromIdentifiers(KfinanceTool):
         )
 
 
-class GetAnalystRecommendationsFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, AnalystRecommendations]
+class GetAnalystRecommendationsFromIdentifiersResp(
+    ToolRespWithIdInfoAndErrors[AnalystRecommendations]
+):
+    pass
 
 
 class GetAnalystRecommendationsFromIdentifiers(KfinanceTool):
@@ -228,7 +229,9 @@ async def get_estimates_from_identifiers(
                 error_msg = f"{task.result_key}: {resp.error}"
                 errors.append(error_msg)
 
-    resp_model = GetEstimatesFromIdentifiersResp(results=results, errors=errors)
+    resp_model = GetEstimatesFromIdentifiersResp(
+        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+    )
 
     # Add explanatory notes
     insert_fiscal_period_notes(
@@ -316,7 +319,9 @@ async def get_consensus_target_price_from_identifiers(
                 error_msg = f"{task.result_key}: {resp.error}"
                 errors.append(error_msg)
 
-    return GetConsensusTargetPriceFromIdentifiersResp(results=results, errors=errors)
+    return GetConsensusTargetPriceFromIdentifiersResp(
+        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+    )
 
 
 async def fetch_consensus_target_price_from_company_id(
@@ -366,7 +371,9 @@ async def get_analyst_recommendations_from_identifiers(
                 error_msg = f"{task.result_key}: {resp.error}"
                 errors.append(error_msg)
 
-    return GetAnalystRecommendationsFromIdentifiersResp(results=results, errors=errors)
+    return GetAnalystRecommendationsFromIdentifiersResp(
+        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+    )
 
 
 async def fetch_analyst_recommendations_from_company_id(

--- a/kfinance/domains/estimates/tests/test_estimate_tools.py
+++ b/kfinance/domains/estimates/tests/test_estimate_tools.py
@@ -111,7 +111,7 @@ class TestEstimates:
         """
 
         expected_resp = GetEstimatesFromIdentifiersResp(
-            results={"SPGI": Estimates.model_validate(self.estimates_data)},
+            identifier_results={"SPGI": Estimates.model_validate(self.estimates_data)},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -143,7 +143,7 @@ class TestEstimates:
         )
 
         expected_resp = GetEstimatesFromIdentifiersResp(
-            results={},
+            identifier_results={},
             errors=["SPGI: No results found."],
             notes=[FISCAL_PERIOD_WARNING, FISCAL_YEAR_TERMINOLOGY_WARNING],
         )
@@ -249,7 +249,7 @@ class TestEstimates:
         )
 
         expected_resp = GetConsensusTargetPriceFromIdentifiersResp(
-            results={},
+            identifier_results={},
             errors=["SPGI: No consensus target price found."],
         )
 
@@ -296,7 +296,9 @@ class TestEstimates:
         )
 
         expected_resp = GetConsensusTargetPriceFromIdentifiersResp(
-            results={"SPGI": ConsensusTargetPrice.model_validate(consensus_target_price_data)},
+            identifier_results={
+                "SPGI": ConsensusTargetPrice.model_validate(consensus_target_price_data)
+            },
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -361,7 +363,7 @@ class TestEstimates:
         )
 
         expected_resp = GetAnalystRecommendationsFromIdentifiersResp(
-            results={},
+            identifier_results={},
             errors=["SPGI: No analyst recommendations found."],
         )
 
@@ -406,7 +408,9 @@ class TestEstimates:
         )
 
         expected_resp = GetAnalystRecommendationsFromIdentifiersResp(
-            results={"SPGI": AnalystRecommendations.model_validate(analyst_recommendations_data)},
+            identifier_results={
+                "SPGI": AnalystRecommendations.model_validate(analyst_recommendations_data)
+            },
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],

--- a/kfinance/domains/estimates/tests/test_estimate_tools.py
+++ b/kfinance/domains/estimates/tests/test_estimate_tools.py
@@ -112,6 +112,7 @@ class TestEstimates:
 
         expected_resp = GetEstimatesFromIdentifiersResp(
             identifier_results={"SPGI": Estimates.model_validate(self.estimates_data)},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -144,6 +145,7 @@ class TestEstimates:
 
         expected_resp = GetEstimatesFromIdentifiersResp(
             identifier_results={},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=["SPGI: No results found."],
             notes=[FISCAL_PERIOD_WARNING, FISCAL_YEAR_TERMINOLOGY_WARNING],
         )
@@ -187,7 +189,6 @@ class TestEstimates:
             result=Estimates.model_validate(guidance_data),
         )
         assert resp == expected_resp
-        assert resp.result.estimate_type == EstimateType.guidance
 
     @pytest.mark.asyncio
     async def test_fetch_consensus_target_price_from_company_id(
@@ -250,6 +251,7 @@ class TestEstimates:
 
         expected_resp = GetConsensusTargetPriceFromIdentifiersResp(
             identifier_results={},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=["SPGI: No consensus target price found."],
         )
 
@@ -299,6 +301,7 @@ class TestEstimates:
             identifier_results={
                 "SPGI": ConsensusTargetPrice.model_validate(consensus_target_price_data)
             },
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -364,6 +367,7 @@ class TestEstimates:
 
         expected_resp = GetAnalystRecommendationsFromIdentifiersResp(
             identifier_results={},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=["SPGI: No analyst recommendations found."],
         )
 
@@ -411,6 +415,7 @@ class TestEstimates:
             identifier_results={
                 "SPGI": AnalystRecommendations.model_validate(analyst_recommendations_data)
             },
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],

--- a/kfinance/domains/line_items/line_item_tools.py
+++ b/kfinance/domains/line_items/line_item_tools.py
@@ -23,7 +23,7 @@ from kfinance.domains.line_items.response_notes import (
 from kfinance.integrations.tool_calling.tool_calling_models import (
     KfinanceTool,
     ToolArgsWithIdentifiers,
-    ToolRespWithErrors,
+    ToolRespWithIdInfoAndErrors,
     ValidQuarter,
 )
 
@@ -143,8 +143,7 @@ class GetFinancialLineItemFromIdentifiersArgs(ToolArgsWithIdentifiers):
         return values
 
 
-class GetFinancialLineItemFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, LineItemResp]  # identifier -> response
+class GetFinancialLineItemFromIdentifiersResp(ToolRespWithIdInfoAndErrors[LineItemResp]):
     notes: list[str] = Field(default_factory=list)
 
 
@@ -280,7 +279,9 @@ async def get_financial_line_item_from_identifiers(
         for line_item_response in results.values():
             line_item_response.remove_all_periods_other_than_the_most_recent_one()
 
-    resp_model = GetFinancialLineItemFromIdentifiersResp(results=results, errors=errors)
+    resp_model = GetFinancialLineItemFromIdentifiersResp(
+        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+    )
 
     # Add explanatory notes
     insert_source_link_note(resp_model)

--- a/kfinance/domains/line_items/line_item_tools.py
+++ b/kfinance/domains/line_items/line_item_tools.py
@@ -280,7 +280,9 @@ async def get_financial_line_item_from_identifiers(
             line_item_response.remove_all_periods_other_than_the_most_recent_one()
 
     resp_model = GetFinancialLineItemFromIdentifiersResp(
-        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+        identifier_results=results,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )
 
     # Add explanatory notes

--- a/kfinance/domains/line_items/tests/test_line_item_tools.py
+++ b/kfinance/domains/line_items/tests/test_line_item_tools.py
@@ -5,7 +5,7 @@ from pytest_httpx import HTTPXMock
 
 from kfinance.client.kfinance import Client
 from kfinance.client.models.response_models import PostResponse
-from kfinance.conftest import SPGI_ID_TRIPLE
+from kfinance.conftest import FAKE_COMPANY_1_ID_TRIPLE, FAKE_COMPANY_2_ID_TRIPLE, SPGI_ID_TRIPLE
 from kfinance.domains.companies.company_models import COMPANY_ID_PREFIX
 from kfinance.domains.line_items.line_item_models import CalendarType, LineItemResp, LineItemScore
 from kfinance.domains.line_items.line_item_tools import (
@@ -111,6 +111,7 @@ class TestGetFinancialLineItemFromIdentifiers:
 
         expected_response = GetFinancialLineItemFromIdentifiersResp(
             identifier_results={"SPGI": LineItemResp.model_validate(self.line_item_resp)},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -145,6 +146,7 @@ class TestGetFinancialLineItemFromIdentifiers:
 
         expected_resp = GetFinancialLineItemFromIdentifiersResp(
             identifier_results={},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=["SPGI: No results found."],
             notes=[SOURCE_LINK_NOTE, FISCAL_PERIOD_WARNING, FISCAL_YEAR_TERMINOLOGY_WARNING],
         )
@@ -189,6 +191,7 @@ class TestGetFinancialLineItemFromIdentifiers:
         )
         expected_response = GetFinancialLineItemFromIdentifiersResp(
             identifier_results={"C_1": line_item_resp, "C_2": line_item_resp},
+            identifier_info={"C_1": FAKE_COMPANY_1_ID_TRIPLE, "C_2": FAKE_COMPANY_2_ID_TRIPLE},
             notes=[SOURCE_LINK_NOTE, FISCAL_PERIOD_WARNING, FISCAL_YEAR_TERMINOLOGY_WARNING],
         )
 
@@ -200,7 +203,7 @@ class TestGetFinancialLineItemFromIdentifiers:
 
         assert resp == expected_response
 
-    def test_line_items_and_aliases_included_in_schema(self, mock_client: Client):
+    def test_line_items_and_aliases_included_in_schema(self, mock_client: Client) -> None:
         """
         GIVEN a GetFinancialLineItemFromIdentifiers tool
         WHEN we generate an openai schema from the tool
@@ -233,7 +236,7 @@ class TestFindSimilarLineItems:
         "ebitda": "Earnings before interest, taxes, depreciation, and amortization.",
     }
 
-    def test_exact_keyword_match(self):
+    def test_exact_keyword_match(self) -> None:
         """
         GIVEN a preset descriptors dictionary
         WHEN searching for 'revenues' (similar to 'revenue')
@@ -247,7 +250,7 @@ class TestFindSimilarLineItems:
         result_names = [item.name for item in results]
         assert "revenue" in result_names or "total_revenue" in result_names
 
-    def test_acronym_matching(self):
+    def test_acronym_matching(self) -> None:
         """
         GIVEN a preset descriptors dictionary
         WHEN searching for 'R&D' (abbreviation)
@@ -259,7 +262,7 @@ class TestFindSimilarLineItems:
         # Should find r_and_d_expense or research_and_development_expense
         assert any("research" in name or "r_and_d" in name for name in result_names)
 
-    def test_multiple_word_matching(self):
+    def test_multiple_word_matching(self) -> None:
         """
         GIVEN a preset descriptors dictionary
         WHEN searching for 'cost goods'
@@ -270,7 +273,7 @@ class TestFindSimilarLineItems:
         result_names = [item.name for item in results]
         assert "cost_of_goods_sold" in result_names or "cogs" in result_names
 
-    def test_description_matching(self):
+    def test_description_matching(self) -> None:
         """
         GIVEN a preset descriptors dictionary
         WHEN searching for 'profit'
@@ -283,7 +286,7 @@ class TestFindSimilarLineItems:
         result_names = [item.name for item in results]
         assert any("profit" in name or "income" in name for name in result_names)
 
-    def test_empty_descriptors(self):
+    def test_empty_descriptors(self) -> None:
         """
         GIVEN an empty descriptors dictionary
         WHEN searching for any term
@@ -292,7 +295,7 @@ class TestFindSimilarLineItems:
         results = _find_similar_line_items("revenue", {}, max_suggestions=5)
         assert results == []
 
-    def test_no_matches(self):
+    def test_no_matches(self) -> None:
         """
         GIVEN a preset descriptors dictionary
         WHEN searching for completely unrelated term
@@ -302,7 +305,7 @@ class TestFindSimilarLineItems:
         # Should return empty or very few results since threshold is > 0.1
         assert len(results) <= 2  # May have some weak matches but should be minimal
 
-    def test_max_suggestions_respected(self):
+    def test_max_suggestions_respected(self) -> None:
         """
         GIVEN a preset descriptors dictionary
         WHEN searching with max_suggestions=3
@@ -311,7 +314,7 @@ class TestFindSimilarLineItems:
         results = _find_similar_line_items("income", self.TEST_DESCRIPTORS, max_suggestions=3)
         assert len(results) <= 3
 
-    def test_score_ordering(self):
+    def test_score_ordering(self) -> None:
         """
         GIVEN a preset descriptors dictionary
         WHEN searching for a term
@@ -323,7 +326,7 @@ class TestFindSimilarLineItems:
             for i in range(len(results) - 1):
                 assert results[i].score >= results[i + 1].score
 
-    def test_score_threshold(self):
+    def test_score_threshold(self) -> None:
         """
         GIVEN a preset descriptors dictionary
         WHEN searching for a term
@@ -334,7 +337,7 @@ class TestFindSimilarLineItems:
         for item in results:
             assert item.score > 0.1
 
-    def test_lineitemscore_structure(self):
+    def test_lineitemscore_structure(self) -> None:
         """
         GIVEN a preset descriptors dictionary
         WHEN searching for a term

--- a/kfinance/domains/line_items/tests/test_line_item_tools.py
+++ b/kfinance/domains/line_items/tests/test_line_item_tools.py
@@ -110,7 +110,7 @@ class TestGetFinancialLineItemFromIdentifiers:
         """
 
         expected_response = GetFinancialLineItemFromIdentifiersResp(
-            results={"SPGI": LineItemResp.model_validate(self.line_item_resp)},
+            identifier_results={"SPGI": LineItemResp.model_validate(self.line_item_resp)},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -144,7 +144,7 @@ class TestGetFinancialLineItemFromIdentifiers:
         )
 
         expected_resp = GetFinancialLineItemFromIdentifiersResp(
-            results={},
+            identifier_results={},
             errors=["SPGI: No results found."],
             notes=[SOURCE_LINK_NOTE, FISCAL_PERIOD_WARNING, FISCAL_YEAR_TERMINOLOGY_WARNING],
         )
@@ -188,7 +188,7 @@ class TestGetFinancialLineItemFromIdentifiers:
             }
         )
         expected_response = GetFinancialLineItemFromIdentifiersResp(
-            results={"C_1": line_item_resp, "C_2": line_item_resp},
+            identifier_results={"C_1": line_item_resp, "C_2": line_item_resp},
             notes=[SOURCE_LINK_NOTE, FISCAL_PERIOD_WARNING, FISCAL_YEAR_TERMINOLOGY_WARNING],
         )
 

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
@@ -17,11 +17,12 @@ from kfinance.integrations.tool_calling.tool_calling_models import (
     ToolArgsWithIdentifier,
     ToolArgsWithIdentifiers,
     ToolRespWithErrors,
+    ToolRespWithIdInfoAndErrors,
 )
 
 
-class GetMergersFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, MergersResp]
+class GetMergersFromIdentifiersResp(ToolRespWithIdInfoAndErrors[MergersResp]):
+    pass
 
 
 class GetMergersFromIdentifiers(KfinanceTool):
@@ -155,7 +156,9 @@ async def get_mergers_from_identifiers(
         else:
             results[task.result_key] = task.result
 
-    return GetMergersFromIdentifiersResp(results=results, errors=errors)
+    return GetMergersFromIdentifiersResp(
+        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+    )
 
 
 async def fetch_mergers_from_company_id(

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
@@ -157,7 +157,9 @@ async def get_mergers_from_identifiers(
             results[task.result_key] = task.result
 
     return GetMergersFromIdentifiersResp(
-        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+        identifier_results=results,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )
 
 

--- a/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
@@ -67,6 +67,7 @@ class TestMergersAndAcquisitions:
 
         expected_resp = GetMergersFromIdentifiersResp(
             identifier_results={"SPGI": MERGERS_RESP},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],

--- a/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
@@ -66,7 +66,7 @@ class TestMergersAndAcquisitions:
         """
 
         expected_resp = GetMergersFromIdentifiersResp(
-            results={"SPGI": MERGERS_RESP},
+            identifier_results={"SPGI": MERGERS_RESP},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],

--- a/kfinance/domains/prices/price_tools.py
+++ b/kfinance/domains/prices/price_tools.py
@@ -13,7 +13,7 @@ from kfinance.domains.prices.price_models import HistoryMetadataResp, PriceHisto
 from kfinance.integrations.tool_calling.tool_calling_models import (
     KfinanceTool,
     ToolArgsWithIdentifiers,
-    ToolRespWithErrors,
+    ToolRespWithIdInfoAndErrors,
 )
 
 
@@ -34,8 +34,8 @@ class GetPricesFromIdentifiersArgs(ToolArgsWithIdentifiers):
     )
 
 
-class GetPricesFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, PriceHistory]
+class GetPricesFromIdentifiersResp(ToolRespWithIdInfoAndErrors[PriceHistory]):
+    pass
 
 
 class GetPricesFromIdentifiers(KfinanceTool):
@@ -80,8 +80,8 @@ class GetPricesFromIdentifiers(KfinanceTool):
         )
 
 
-class GetHistoryMetadataFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, HistoryMetadataResp]
+class GetHistoryMetadataFromIdentifiersResp(ToolRespWithIdInfoAndErrors[HistoryMetadataResp]):
+    pass
 
 
 class GetHistoryMetadataFromIdentifiers(KfinanceTool):
@@ -154,7 +154,9 @@ async def get_prices_from_identifiers(
         for price_response in results.values():
             price_response.prices = price_response.prices[-1:]
 
-    return GetPricesFromIdentifiersResp(results=results, errors=errors)
+    return GetPricesFromIdentifiersResp(
+        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+    )
 
 
 async def fetch_price_history_from_trading_item_id(
@@ -209,7 +211,9 @@ async def get_history_metadata_from_identifiers(
         else:
             results[task.result_key] = task.result
 
-    return GetHistoryMetadataFromIdentifiersResp(results=results, errors=errors)
+    return GetHistoryMetadataFromIdentifiersResp(
+        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+    )
 
 
 async def fetch_history_metadata_from_trading_item_id(

--- a/kfinance/domains/prices/price_tools.py
+++ b/kfinance/domains/prices/price_tools.py
@@ -155,7 +155,9 @@ async def get_prices_from_identifiers(
             price_response.prices = price_response.prices[-1:]
 
     return GetPricesFromIdentifiersResp(
-        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+        identifier_results=results,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )
 
 
@@ -212,7 +214,9 @@ async def get_history_metadata_from_identifiers(
             results[task.result_key] = task.result
 
     return GetHistoryMetadataFromIdentifiersResp(
-        identifier_results=results, identifier_info=id_triple_resp, errors=errors
+        identifier_results=results,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )
 
 

--- a/kfinance/domains/prices/tests/test_price_tools.py
+++ b/kfinance/domains/prices/tests/test_price_tools.py
@@ -3,7 +3,12 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from kfinance.client.models.date_and_period_models import Periodicity
-from kfinance.conftest import SPGI_ID_TRIPLE
+from kfinance.conftest import (
+    FAKE_COMPANY_1_ID_TRIPLE,
+    FAKE_COMPANY_2_ID_TRIPLE,
+    SPGI_ID_TRIPLE,
+    SPGI_TRADING_ITEM_ID,
+)
 from kfinance.domains.companies.company_models import COMPANY_ID_PREFIX
 from kfinance.domains.prices.price_models import HistoryMetadataResp, PriceHistory
 from kfinance.domains.prices.price_tools import (
@@ -44,7 +49,7 @@ class TestPrices:
         """Add mock response for SPGI prices."""
         httpx_mock.add_response(
             method="GET",
-            url=f"https://kfinance.kensho.com/api/v1/pricing/{SPGI_ID_TRIPLE.trading_item_id}/none/none/day/adjusted",
+            url=f"https://kfinance.kensho.com/api/v1/pricing/{SPGI_TRADING_ITEM_ID}/none/none/day/adjusted",
             json=self.prices_resp,
             is_optional=True,
         )
@@ -61,7 +66,7 @@ class TestPrices:
         """
 
         resp = await fetch_price_history_from_trading_item_id(
-            trading_item_id=SPGI_ID_TRIPLE.trading_item_id,
+            trading_item_id=SPGI_TRADING_ITEM_ID,
             httpx_client=httpx_client,
         )
 
@@ -80,7 +85,8 @@ class TestPrices:
         """
 
         expected_resp = GetPricesFromIdentifiersResp(
-            results={"SPGI": PriceHistory.model_validate(self.prices_resp)},
+            identifier_results={"SPGI": PriceHistory.model_validate(self.prices_resp)},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -128,10 +134,11 @@ class TestPrices:
         )
 
         expected_response = GetPricesFromIdentifiersResp(
-            results={
+            identifier_results={
                 "C_1": expected_single_company_response,
                 "C_2": expected_single_company_response,
             },
+            identifier_info={"C_1": FAKE_COMPANY_1_ID_TRIPLE, "C_2": FAKE_COMPANY_2_ID_TRIPLE},
         )
 
         resp = await get_prices_from_identifiers(
@@ -159,12 +166,12 @@ class TestPrices:
 
         httpx_mock.add_response(
             method="GET",
-            url=f"https://kfinance.kensho.com/api/v1/pricing/{SPGI_ID_TRIPLE.trading_item_id}/2024-04-01/2024-04-30/week/unadjusted",
+            url=f"https://kfinance.kensho.com/api/v1/pricing/{SPGI_TRADING_ITEM_ID}/2024-04-01/2024-04-30/week/unadjusted",
             json=self.prices_resp,
         )
 
         resp = await fetch_price_history_from_trading_item_id(
-            trading_item_id=SPGI_ID_TRIPLE.trading_item_id,
+            trading_item_id=SPGI_TRADING_ITEM_ID,
             httpx_client=httpx_client,
             start_date=start_date,
             end_date=end_date,
@@ -190,7 +197,7 @@ class TestHistoryMetadata:
         """Add mock response for SPGI history metadata."""
         httpx_mock.add_response(
             method="GET",
-            url=f"https://kfinance.kensho.com/api/v1/pricing/{SPGI_ID_TRIPLE.trading_item_id}/metadata",
+            url=f"https://kfinance.kensho.com/api/v1/pricing/{SPGI_TRADING_ITEM_ID}/metadata",
             json=self.metadata_resp,
             is_optional=True,
         )
@@ -207,7 +214,7 @@ class TestHistoryMetadata:
         """
 
         resp = await fetch_history_metadata_from_trading_item_id(
-            trading_item_id=SPGI_ID_TRIPLE.trading_item_id,
+            trading_item_id=SPGI_TRADING_ITEM_ID,
             httpx_client=httpx_client,
         )
 
@@ -227,6 +234,7 @@ class TestHistoryMetadata:
 
         expected_resp = GetHistoryMetadataFromIdentifiersResp(
             identifier_results={"SPGI": HistoryMetadataResp.model_validate(self.metadata_resp)},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],

--- a/kfinance/domains/prices/tests/test_price_tools.py
+++ b/kfinance/domains/prices/tests/test_price_tools.py
@@ -226,7 +226,7 @@ class TestHistoryMetadata:
         """
 
         expected_resp = GetHistoryMetadataFromIdentifiersResp(
-            results={"SPGI": HistoryMetadataResp.model_validate(self.metadata_resp)},
+            identifier_results={"SPGI": HistoryMetadataResp.model_validate(self.metadata_resp)},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],

--- a/kfinance/domains/rounds_of_funding/rounds_of_funding_tools.py
+++ b/kfinance/domains/rounds_of_funding/rounds_of_funding_tools.py
@@ -21,6 +21,7 @@ from kfinance.integrations.tool_calling.tool_calling_models import (
     KfinanceTool,
     ToolArgsWithIdentifiers,
     ToolRespWithErrors,
+    ToolRespWithIdInfoAndErrors,
 )
 
 
@@ -44,8 +45,8 @@ class GetRoundsofFundingFromIdentifiersArgs(ToolArgsWithIdentifiers):
     )
 
 
-class GetRoundsOfFundingFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, RoundsOfFundingResp]
+class GetRoundsOfFundingFromIdentifiersResp(ToolRespWithIdInfoAndErrors[RoundsOfFundingResp]):
+    pass
 
 
 def filter_rounds_of_funding_responses_by_date_range(
@@ -224,8 +225,8 @@ class GetFundingSummaryFromIdentifiersArgs(ToolArgsWithIdentifiers):
     pass  # Only needs identifiers, no additional args needed
 
 
-class GetFundingSummaryFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, FundingSummary]
+class GetFundingSummaryFromIdentifiersResp(ToolRespWithIdInfoAndErrors[FundingSummary]):
+    pass
 
 
 def build_funding_summaries_from_rof_responses(
@@ -363,7 +364,9 @@ async def get_rounds_of_funding_from_identifiers(
         filtered_responses, sort_order, limit
     )
 
-    return GetRoundsOfFundingFromIdentifiersResp(results=sorted_responses, errors=errors)
+    return GetRoundsOfFundingFromIdentifiersResp(
+        identifier_results=sorted_responses, identifier_info=id_triple_resp, errors=errors
+    )
 
 
 async def fetch_rounds_of_funding_from_company_id(
@@ -566,4 +569,6 @@ async def get_funding_summary_from_identifiers(
         rounds_of_funding_responses, detailed_round_info_responses
     )
 
-    return GetFundingSummaryFromIdentifiersResp(results=summaries, errors=errors)
+    return GetFundingSummaryFromIdentifiersResp(
+        identifier_results=summaries, identifier_info=id_triple_resp, errors=errors
+    )

--- a/kfinance/domains/rounds_of_funding/rounds_of_funding_tools.py
+++ b/kfinance/domains/rounds_of_funding/rounds_of_funding_tools.py
@@ -365,7 +365,9 @@ async def get_rounds_of_funding_from_identifiers(
     )
 
     return GetRoundsOfFundingFromIdentifiersResp(
-        identifier_results=sorted_responses, identifier_info=id_triple_resp, errors=errors
+        identifier_results=sorted_responses,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )
 
 
@@ -570,5 +572,7 @@ async def get_funding_summary_from_identifiers(
     )
 
     return GetFundingSummaryFromIdentifiersResp(
-        identifier_results=summaries, identifier_info=id_triple_resp, errors=errors
+        identifier_results=summaries,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )

--- a/kfinance/domains/rounds_of_funding/tests/test_rounds_of_funding_tools.py
+++ b/kfinance/domains/rounds_of_funding/tests/test_rounds_of_funding_tools.py
@@ -4,7 +4,7 @@ import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
-from kfinance.conftest import SPGI_ID_TRIPLE
+from kfinance.conftest import FAKE_COMPANY_1_ID_TRIPLE, FAKE_COMPANY_2_ID_TRIPLE, SPGI_ID_TRIPLE
 from kfinance.domains.companies.company_models import COMPANY_ID_PREFIX
 from kfinance.domains.rounds_of_funding.rounds_of_funding_models import (
     AdvisorResp,
@@ -178,7 +178,10 @@ class TestRoundsOfFunding:
         """
 
         expected_resp = GetRoundsOfFundingFromIdentifiersResp(
-            results={"SPGI": RoundsOfFundingResp.model_validate(self.rounds_of_funding_response)},
+            identifier_results={
+                "SPGI": RoundsOfFundingResp.model_validate(self.rounds_of_funding_response)
+            },
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -470,6 +473,7 @@ class TestRoundsOfFunding:
                 "C_1": expected_summary,
                 "C_2": expected_summary.model_copy(update={"company_id": "C_2"}),
             },
+            identifier_info={"C_1": FAKE_COMPANY_1_ID_TRIPLE, "C_2": FAKE_COMPANY_2_ID_TRIPLE},
         )
 
         resp = await get_funding_summary_from_identifiers(

--- a/kfinance/domains/rounds_of_funding/tests/test_rounds_of_funding_tools.py
+++ b/kfinance/domains/rounds_of_funding/tests/test_rounds_of_funding_tools.py
@@ -466,7 +466,7 @@ class TestRoundsOfFunding:
         )
 
         expected_response = GetFundingSummaryFromIdentifiersResp(
-            results={
+            identifier_results={
                 "C_1": expected_summary,
                 "C_2": expected_summary.model_copy(update={"company_id": "C_2"}),
             },

--- a/kfinance/domains/segments/segment_tools.py
+++ b/kfinance/domains/segments/segment_tools.py
@@ -166,7 +166,9 @@ async def get_segments_from_identifiers(
             segments_response.remove_all_periods_other_than_the_most_recent_one()
 
     resp_model = GetSegmentsFromIdentifiersResp(
-        identifier_results=identifier_to_results, identifier_info=id_triple_resp, errors=errors
+        identifier_results=identifier_to_results,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )
 
     # Add explanatory notes

--- a/kfinance/domains/segments/segment_tools.py
+++ b/kfinance/domains/segments/segment_tools.py
@@ -16,7 +16,7 @@ from kfinance.domains.segments.segment_models import SegmentsResp, SegmentType
 from kfinance.integrations.tool_calling.tool_calling_models import (
     KfinanceTool,
     ToolArgsWithIdentifiers,
-    ToolRespWithErrors,
+    ToolRespWithIdInfoAndErrors,
     ValidQuarter,
 )
 
@@ -41,8 +41,7 @@ class GetSegmentsFromIdentifiersArgs(ToolArgsWithIdentifiers):
     )
 
 
-class GetSegmentsFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, SegmentsResp]  # identifier -> response
+class GetSegmentsFromIdentifiersResp(ToolRespWithIdInfoAndErrors[SegmentsResp]):
     notes: list[str] = Field(default_factory=list)
 
 
@@ -166,7 +165,9 @@ async def get_segments_from_identifiers(
         for segments_response in identifier_to_results.values():
             segments_response.remove_all_periods_other_than_the_most_recent_one()
 
-    resp_model = GetSegmentsFromIdentifiersResp(results=identifier_to_results, errors=errors)
+    resp_model = GetSegmentsFromIdentifiersResp(
+        identifier_results=identifier_to_results, identifier_info=id_triple_resp, errors=errors
+    )
 
     # Add explanatory notes
     insert_fiscal_period_notes(

--- a/kfinance/domains/segments/tests/test_segment_tools.py
+++ b/kfinance/domains/segments/tests/test_segment_tools.py
@@ -3,7 +3,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from kfinance.client.models.response_models import PostResponse
-from kfinance.conftest import SPGI_ID_TRIPLE
+from kfinance.conftest import FAKE_COMPANY_1_ID_TRIPLE, FAKE_COMPANY_2_ID_TRIPLE, SPGI_ID_TRIPLE
 from kfinance.domains.companies.company_models import COMPANY_ID_PREFIX
 from kfinance.domains.line_items.response_notes import (
     FISCAL_PERIOD_WARNING,
@@ -107,6 +107,7 @@ class TestSegments:
 
         expected_resp = GetSegmentsFromIdentifiersResp(
             identifier_results={"SPGI": SegmentsResp.model_validate(self.segments_response)},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -160,6 +161,7 @@ class TestSegments:
                 "C_1": expected_single_company_response,
                 "C_2": expected_single_company_response,
             },
+            identifier_info={"C_1": FAKE_COMPANY_1_ID_TRIPLE, "C_2": FAKE_COMPANY_2_ID_TRIPLE},
             notes=[FISCAL_PERIOD_WARNING, FISCAL_YEAR_TERMINOLOGY_WARNING],
         )
 
@@ -183,6 +185,7 @@ class TestSegments:
 
         expected_resp = GetSegmentsFromIdentifiersResp(
             identifier_results={},
+            identifier_info={},
             errors=[
                 "No identification triple found for the provided identifier:"
                 " NON-EXISTENT of type: ticker"

--- a/kfinance/domains/segments/tests/test_segment_tools.py
+++ b/kfinance/domains/segments/tests/test_segment_tools.py
@@ -106,7 +106,7 @@ class TestSegments:
         """
 
         expected_resp = GetSegmentsFromIdentifiersResp(
-            results={"SPGI": SegmentsResp.model_validate(self.segments_response)},
+            identifier_results={"SPGI": SegmentsResp.model_validate(self.segments_response)},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -156,7 +156,7 @@ class TestSegments:
         )
 
         expected_response = GetSegmentsFromIdentifiersResp(
-            results={
+            identifier_results={
                 "C_1": expected_single_company_response,
                 "C_2": expected_single_company_response,
             },
@@ -182,7 +182,7 @@ class TestSegments:
         """
 
         expected_resp = GetSegmentsFromIdentifiersResp(
-            results={},
+            identifier_results={},
             errors=[
                 "No identification triple found for the provided identifier:"
                 " NON-EXISTENT of type: ticker"

--- a/kfinance/domains/statements/statement_tools.py
+++ b/kfinance/domains/statements/statement_tools.py
@@ -19,7 +19,7 @@ from kfinance.domains.statements.statement_models import (
 from kfinance.integrations.tool_calling.tool_calling_models import (
     KfinanceTool,
     ToolArgsWithIdentifiers,
-    ToolRespWithErrors,
+    ToolRespWithIdInfoAndErrors,
     ValidQuarter,
 )
 
@@ -56,8 +56,7 @@ class GetFinancialStatementFromIdentifiersArgs(ToolArgsWithIdentifiers):
     )
 
 
-class GetFinancialStatementFromIdentifiersResp(ToolRespWithErrors):
-    results: dict[str, StatementsResp]  # identifier -> response
+class GetFinancialStatementFromIdentifiersResp(ToolRespWithIdInfoAndErrors[StatementsResp]):
     notes: list[str] = Field(default_factory=list)
 
 
@@ -190,7 +189,7 @@ async def get_financial_statement_from_identifiers(
             result.remove_all_periods_other_than_the_most_recent_one()
 
     resp_model = GetFinancialStatementFromIdentifiersResp(
-        results=identifier_to_results, errors=errors
+        identifier_results=identifier_to_results, identifier_info=id_triple_resp, errors=errors
     )
 
     # Add explanatory notes

--- a/kfinance/domains/statements/statement_tools.py
+++ b/kfinance/domains/statements/statement_tools.py
@@ -189,7 +189,9 @@ async def get_financial_statement_from_identifiers(
             result.remove_all_periods_other_than_the_most_recent_one()
 
     resp_model = GetFinancialStatementFromIdentifiersResp(
-        identifier_results=identifier_to_results, identifier_info=id_triple_resp, errors=errors
+        identifier_results=identifier_to_results,
+        identifier_info=id_triple_resp.identifiers_to_id_triples,
+        errors=errors,
     )
 
     # Add explanatory notes

--- a/kfinance/domains/statements/tests/test_statement_tools.py
+++ b/kfinance/domains/statements/tests/test_statement_tools.py
@@ -97,7 +97,7 @@ class TestStatements:
         """
 
         expected_resp = GetFinancialStatementFromIdentifiersResp(
-            results={"SPGI": StatementsResp.model_validate(self.statement_resp)},
+            identifier_results={"SPGI": StatementsResp.model_validate(self.statement_resp)},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -130,7 +130,7 @@ class TestStatements:
         )
 
         expected_resp = GetFinancialStatementFromIdentifiersResp(
-            results={},
+            identifier_results={},
             errors=["SPGI: No results found."],
             notes=[FISCAL_PERIOD_WARNING, FISCAL_YEAR_TERMINOLOGY_WARNING],
         )
@@ -175,7 +175,7 @@ class TestStatements:
         )
 
         expected_response = GetFinancialStatementFromIdentifiersResp(
-            results={
+            identifier_results={
                 "C_1": expected_single_company_response,
                 "C_2": expected_single_company_response,
             },
@@ -201,7 +201,7 @@ class TestStatements:
         """
 
         expected_resp = GetFinancialStatementFromIdentifiersResp(
-            results={},
+            identifier_results={},
             errors=[
                 "No identification triple found for the provided identifier:"
                 " NON-EXISTENT of type: ticker"

--- a/kfinance/domains/statements/tests/test_statement_tools.py
+++ b/kfinance/domains/statements/tests/test_statement_tools.py
@@ -3,7 +3,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from kfinance.client.models.response_models import PostResponse
-from kfinance.conftest import SPGI_ID_TRIPLE
+from kfinance.conftest import FAKE_COMPANY_1_ID_TRIPLE, FAKE_COMPANY_2_ID_TRIPLE, SPGI_ID_TRIPLE
 from kfinance.domains.companies.company_models import COMPANY_ID_PREFIX
 from kfinance.domains.line_items.response_notes import (
     FISCAL_PERIOD_WARNING,
@@ -98,6 +98,7 @@ class TestStatements:
 
         expected_resp = GetFinancialStatementFromIdentifiersResp(
             identifier_results={"SPGI": StatementsResp.model_validate(self.statement_resp)},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=[
                 "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
             ],
@@ -131,6 +132,7 @@ class TestStatements:
 
         expected_resp = GetFinancialStatementFromIdentifiersResp(
             identifier_results={},
+            identifier_info={"SPGI": SPGI_ID_TRIPLE},
             errors=["SPGI: No results found."],
             notes=[FISCAL_PERIOD_WARNING, FISCAL_YEAR_TERMINOLOGY_WARNING],
         )
@@ -179,6 +181,7 @@ class TestStatements:
                 "C_1": expected_single_company_response,
                 "C_2": expected_single_company_response,
             },
+            identifier_info={"C_1": FAKE_COMPANY_1_ID_TRIPLE, "C_2": FAKE_COMPANY_2_ID_TRIPLE},
             notes=[FISCAL_PERIOD_WARNING, FISCAL_YEAR_TERMINOLOGY_WARNING],
         )
 
@@ -202,6 +205,7 @@ class TestStatements:
 
         expected_resp = GetFinancialStatementFromIdentifiersResp(
             identifier_results={},
+            identifier_info={},
             errors=[
                 "No identification triple found for the provided identifier:"
                 " NON-EXISTENT of type: ticker"

--- a/kfinance/integrations/tests/test_example_notebook.py
+++ b/kfinance/integrations/tests/test_example_notebook.py
@@ -42,7 +42,7 @@ def jupyter_kernel_name() -> str:
     )
 
 
-def test_run_notebook(jupyter_kernel_name: str):
+def test_run_notebook(jupyter_kernel_name: str) -> None:
     """
     GIVEN the basic_usage.ipynb notebook
     WHEN the notebook gets run with a mock client and mock responses

--- a/kfinance/integrations/tool_calling/tests/test_tool_calling_models.py
+++ b/kfinance/integrations/tool_calling/tests/test_tool_calling_models.py
@@ -9,7 +9,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from kfinance.client.kfinance import Client
-from kfinance.conftest import SPGI_COMPANY_ID, SPGI_ID_TRIPLE
+from kfinance.conftest import SPGI_COMPANY_ID, SPGI_ID_TRIPLE, SPGI_TICKER
 from kfinance.domains.business_relationships.business_relationship_models import (
     BusinessRelationshipType,
 )
@@ -48,18 +48,18 @@ class TestGetEndpointsFromToolCallsWithGrounding:
             "name": "S&P Global Inc.",
             "status": "Operating",
             "company_id": f"{COMPANY_ID_PREFIX}{SPGI_COMPANY_ID}",
+            "ticker": SPGI_TICKER,
         }
         resp_endpoint = [
             "https://kfinance.kensho.com/api/v1/ids",
             "https://kfinance.kensho.com/api/v1/info/21719",
         ]
         expected_resp = {
-            "data": GetInfoFromIdentifiersResp(
-                identifier_results={"SPGI": resp_data}, identifier_info={"SPGI": SPGI_ID_TRIPLE}
-            ),
+            "data": GetInfoFromIdentifiersResp(results={"SPGI": resp_data}),
             "endpoint_urls": resp_endpoint,
         }
         del resp_data["company_id"]
+        del resp_data["ticker"]
 
         # Mock the /ids endpoint
         httpx_mock.add_response(

--- a/kfinance/integrations/tool_calling/tests/test_tool_calling_models.py
+++ b/kfinance/integrations/tool_calling/tests/test_tool_calling_models.py
@@ -29,7 +29,7 @@ class TestGetEndpointsFromToolCallsWithGrounding:
     @pytest.mark.asyncio
     async def test_get_info_from_identifier_with_grounding(
         self, mock_client: Client, httpx_mock: HTTPXMock
-    ):
+    ) -> None:
         """
         GIVEN a KfinanceTool tool
         WHEN we run the tool with `run_with_grounding`
@@ -47,7 +47,9 @@ class TestGetEndpointsFromToolCallsWithGrounding:
             "https://kfinance.kensho.com/api/v1/info/21719",
         ]
         expected_resp = {
-            "data": GetInfoFromIdentifiersResp.model_validate({"results": {"SPGI": resp_data}}),
+            "data": GetInfoFromIdentifiersResp(
+                identifier_results={"SPGI": resp_data}, identifier_info={"SPGI": SPGI_ID_TRIPLE}
+            ),
             "endpoint_urls": resp_endpoint,
         }
         del resp_data["company_id"]
@@ -103,7 +105,7 @@ class TestValidQuarter:
 
 
 class TestRunSyncAndAsync:
-    def test_run_sync_and_async(self, add_spgi_supplier_mock_resp: None, httpx_client: Any):
+    def test_run_sync_and_async(self, add_spgi_supplier_mock_resp: None, httpx_client: Any) -> None:
         """
         GIVEN a sync environment with sync and async clients (via asyncio.run)
         WHEN requests are made with both sync and async clients in a sync
@@ -125,12 +127,12 @@ class TestRunSyncAndAsync:
             datetime(2100, 1, 1).timestamp()
         )
 
-        def run_sync():
+        def run_sync() -> Any:
             tool = GetBusinessRelationshipFromIdentifiers(kfinance_client=sync_client)
             sync_resp = tool.run(args.model_dump(mode="json"))
             return sync_resp
 
-        async def run_async_twice():
+        async def run_async_twice() -> Any:
             tool = GetBusinessRelationshipFromIdentifiers(kfinance_client=async_client)
             async_resp1 = await tool.ainvoke(args.model_dump(mode="json"))
             async_resp2 = await tool.ainvoke(args.model_dump(mode="json"))

--- a/kfinance/integrations/tool_calling/tests/test_tool_calling_models.py
+++ b/kfinance/integrations/tool_calling/tests/test_tool_calling_models.py
@@ -17,12 +17,19 @@ from kfinance.domains.business_relationships.business_relationship_tools import 
     GetBusinessRelationshipFromIdentifiers,
     GetBusinessRelationshipFromIdentifiersArgs,
 )
-from kfinance.domains.companies.company_models import COMPANY_ID_PREFIX
+from kfinance.domains.companies.company_models import (
+    COMPANY_ID_PREFIX,
+    IdentificationTripleWithCompanyInfo,
+)
 from kfinance.domains.companies.company_tools import (
     GetInfoFromIdentifiers,
     GetInfoFromIdentifiersResp,
 )
-from kfinance.integrations.tool_calling.tool_calling_models import ValidQuarter
+from kfinance.integrations.tool_calling.tool_calling_models import (
+    IdentifierInfoWithResult,
+    ToolRespWithIdInfoAndErrors,
+    ValidQuarter,
+)
 
 
 class TestGetEndpointsFromToolCallsWithGrounding:
@@ -150,3 +157,67 @@ class TestRunSyncAndAsync:
         sync_res4 = run_sync()
 
         assert sync_res1 == sync_res2 == sync_res3 == sync_res4 == async_res1 == async_res2
+
+
+class TestToolResp:
+    @pytest.mark.parametrize(
+        "identifier_results,identifier_info,expected_results",
+        [
+            pytest.param({}, {}, {}, id="no ids"),
+            pytest.param(
+                {},
+                {
+                    "COMP": IdentificationTripleWithCompanyInfo(
+                        company_id=10,
+                        security_id=None,
+                        trading_item_id=None,
+                        company_name="Company",
+                        ticker=None,
+                        country=None,
+                    )
+                },
+                {},
+                id="no id results, but some identifier info. there should still be no output results.",
+            ),
+            pytest.param(
+                {"COMP": 5, "OTHER": 7},
+                {
+                    "COMP": IdentificationTripleWithCompanyInfo(
+                        company_id=10,
+                        security_id=None,
+                        trading_item_id=None,
+                        company_name="Company",
+                        ticker=None,
+                        country=None,
+                    ),
+                    "OTHER": IdentificationTripleWithCompanyInfo(
+                        company_id=20,
+                        security_id=1,
+                        trading_item_id=1,
+                        company_name="Other Company",
+                        ticker="EX:OTH",
+                        country="SWE",
+                    ),
+                },
+                {
+                    "COMP": IdentifierInfoWithResult(
+                        company_name="Company", ticker=None, country=None, data=5
+                    ),
+                    "OTHER": IdentifierInfoWithResult(
+                        company_name="Other Company", ticker="EX:OTH", country="SWE", data=7
+                    ),
+                },
+                id="multiple id results",
+            ),
+        ],
+    )
+    def test_tool_resp_with_id_info(
+        self,
+        identifier_results: dict[str, int],
+        identifier_info: dict[str, IdentificationTripleWithCompanyInfo],
+        expected_results: dict[str, IdentifierInfoWithResult[int]],
+    ) -> None:
+        tool_resp = ToolRespWithIdInfoAndErrors[int](
+            identifier_results=identifier_results, identifier_info=identifier_info
+        )
+        assert expected_results == tool_resp.results

--- a/kfinance/integrations/tool_calling/tool_calling_models.py
+++ b/kfinance/integrations/tool_calling/tool_calling_models.py
@@ -203,9 +203,9 @@ class ToolRespWithIdInfoAndErrors(ToolRespWithErrors, Generic[T]):
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def results(self) -> dict[str, IdentifierInfoWithResult]:
+    def results(self) -> dict[str, IdentifierInfoWithResult[T]]:
         """The results field is computed by adding identifier info to the result for each identifier."""
-        output: dict[str, IdentifierInfoWithResult] = {}
+        output: dict[str, IdentifierInfoWithResult[T]] = {}
 
         for identifier, result in self.identifier_results.items():
             id_triple = self.identifier_info.identifiers_to_id_triples[identifier]

--- a/kfinance/integrations/tool_calling/tool_calling_models.py
+++ b/kfinance/integrations/tool_calling/tool_calling_models.py
@@ -192,6 +192,7 @@ T = TypeVar("T")
 class IdentifierInfoWithResult(BaseModel, Generic[T]):
     company_name: str | None
     ticker: str | None
+    country: str | None
     data: T
 
 
@@ -214,6 +215,7 @@ class ToolRespWithIdInfoAndErrors(ToolRespWithErrors, Generic[T]):
                 data=result,
                 company_name=id_triple.company_name,
                 ticker=id_triple.ticker,
+                country=id_triple.country,
             )
 
         return output

--- a/kfinance/integrations/tool_calling/tool_calling_models.py
+++ b/kfinance/integrations/tool_calling/tool_calling_models.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Annotated, Any, Callable, Coroutine, Dict, Literal, Type
+from typing import Annotated, Any, Callable, Coroutine, Dict, Generic, Literal, Type, TypeVar
 
 from asyncer import syncify
 from httpx import HTTPStatusError
@@ -9,11 +9,13 @@ from pydantic import (
     BeforeValidator,
     ConfigDict,
     Field,
+    computed_field,
     model_serializer,
 )
 
 from kfinance.client.kfinance import Client
 from kfinance.client.permission_models import Permission
+from kfinance.domains.companies.company_models import UnifiedIdTripleResponse
 from kfinance.httpx_utils import KfinanceHttpxClient
 
 
@@ -182,3 +184,36 @@ class ToolRespWithErrors(BaseModel):
         if errors:
             data["errors"] = errors
         return data
+
+
+T = TypeVar("T")
+
+
+class IdentifierInfoWithResult(BaseModel, Generic[T]):
+    company_name: str | None
+    ticker: str | None
+    data: T
+
+
+class ToolRespWithIdInfoAndErrors(ToolRespWithErrors, Generic[T]):
+    """A tool response with an `errors` field and a `results` dictionary."""
+
+    identifier_results: dict[str, T] = Field(exclude=True)  # identifier -> response
+    identifier_info: UnifiedIdTripleResponse = Field(exclude=True)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def results(self) -> dict[str, IdentifierInfoWithResult]:
+        """The results field is computed by adding identifier info to the result for each identifier."""
+        output: dict[str, IdentifierInfoWithResult] = {}
+
+        for identifier, result in self.identifier_results.items():
+            id_triple = self.identifier_info.identifiers_to_id_triples[identifier]
+
+            output[identifier] = IdentifierInfoWithResult(
+                data=result,
+                company_name=id_triple.company_name,
+                ticker=id_triple.ticker,
+            )
+
+        return output

--- a/kfinance/integrations/tool_calling/tool_calling_models.py
+++ b/kfinance/integrations/tool_calling/tool_calling_models.py
@@ -15,7 +15,7 @@ from pydantic import (
 
 from kfinance.client.kfinance import Client
 from kfinance.client.permission_models import Permission
-from kfinance.domains.companies.company_models import UnifiedIdTripleResponse
+from kfinance.domains.companies.company_models import IdentificationTripleWithCompanyInfo
 from kfinance.httpx_utils import KfinanceHttpxClient
 
 
@@ -200,7 +200,7 @@ class ToolRespWithIdInfoAndErrors(ToolRespWithErrors, Generic[T]):
     """A tool response with an `errors` field and a `results` dictionary."""
 
     identifier_results: dict[str, T] = Field(exclude=True)  # identifier -> response
-    identifier_info: UnifiedIdTripleResponse = Field(exclude=True)
+    identifier_info: dict[str, IdentificationTripleWithCompanyInfo] = Field(exclude=True)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -209,7 +209,7 @@ class ToolRespWithIdInfoAndErrors(ToolRespWithErrors, Generic[T]):
         output: dict[str, IdentifierInfoWithResult[T]] = {}
 
         for identifier, result in self.identifier_results.items():
-            id_triple = self.identifier_info.identifiers_to_id_triples[identifier]
+            id_triple = self.identifier_info[identifier]
 
             output[identifier] = IdentifierInfoWithResult(
                 data=result,

--- a/kfinance/integrations/tool_calling/tool_calling_models.py
+++ b/kfinance/integrations/tool_calling/tool_calling_models.py
@@ -190,7 +190,7 @@ T = TypeVar("T")
 
 
 class IdentifierInfoWithResult(BaseModel, Generic[T]):
-    company_name: str | None
+    company_name: str
     ticker: str | None
     country: str | None
     data: T

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ force-sort-within-sections = true
 known-third-party = ["wandb"]
 
 [tool.mypy]
+plugins = ["pydantic.mypy"]
 ignore_missing_imports = true
 # `normal` would emit errors for type issues in imported modules, which is unnecessary
 # since we pass files by name when linting.


### PR DESCRIPTION
We recently updated the KFinance API to return more company information in the `/ids` endpoint. With this change, we add this information to tool call responses.