### PR TITLE
Modify revenue aliases

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v6.1.2
+- Update revenue aliases
+
 ## v6.1.1
 - Upgrade cachetools from v6 to v7
 

--- a/kfinance/domains/line_items/line_item_models.py
+++ b/kfinance/domains/line_items/line_item_models.py
@@ -69,8 +69,8 @@ class LineItemType(TypedDict):
 # all of these values must be lower case keys
 LINE_ITEMS: list[LineItemType] = [
     {
-        "name": "revenue",
-        "aliases": {"normal_revenue", "regular_revenue"},
+        "name": "regular_revenue",
+        "aliases": {"normal_revenue", "operating_revenue"},
         "dataitemid": 112,
         "spgi_name": "Revenue",
         "description": "Revenue recognized from primary business activities (excludes non-operating income).",
@@ -133,7 +133,7 @@ LINE_ITEMS: list[LineItemType] = [
     },
     {
         "name": "total_revenue",
-        "aliases": set(),
+        "aliases": {"revenue", "combined_revenue"},
         "dataitemid": 28,
         "spgi_name": "Total Revenue",
         "description": "Sum of operating and non-operating revenue streams for the period.",

--- a/kfinance/domains/line_items/tests/test_line_item_tools.py
+++ b/kfinance/domains/line_items/tests/test_line_item_tools.py
@@ -223,7 +223,7 @@ class TestFindSimilarLineItems:
 
     # Preset test descriptors to ensure consistent results
     TEST_DESCRIPTORS = {
-        "revenue": "Revenue recognized from primary business activities (excludes non-operating income).",
+        "regular_revenue": "Revenue recognized from primary business activities (excludes non-operating income).",
         "total_revenue": "Sum of operating and non-operating revenue streams for the period.",
         "cost_of_goods_sold": "Direct costs attributable to producing goods sold during the period.",
         "cogs": "Direct costs attributable to producing goods sold during the period.",
@@ -248,7 +248,7 @@ class TestFindSimilarLineItems:
         assert isinstance(results[0], LineItemScore)
         # Check that revenue or total_revenue is in top results
         result_names = [item.name for item in results]
-        assert "revenue" in result_names or "total_revenue" in result_names
+        assert "regular_revenue" in result_names or "total_revenue" in result_names
 
     def test_acronym_matching(self) -> None:
         """


### PR DESCRIPTION
user request for "revenue" now routes to "total revenue."