### PR TITLE
Upgrade cachetools to v7 (v6.1.1)

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v6.1.1
+- Upgrade cachetools from v6 to v7
+
 ## v6.1.0
 - Add GetFinancialAuditorsFromIdentifiers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 
 dependencies = [
     "asyncer==0.0.14",
-    "cachetools>=6,<7",
+    "cachetools>=7,<8",
     "click>=8.2.1,<=9",
     "fastmcp>=3.2.0,<4",
     "langchain-core>=1.2.22,<2",
@@ -53,7 +53,7 @@ dev = [
     "requests_mock>=1.12,<2",
     "ruff>=0.9.4,<1",
     "time_machine>=2.1,<3",
-    "types-cachetools>=5.5,<6"
+    "types-cachetools>=5.5,<7"
 ]
 
 


### PR DESCRIPTION
## Summary
- Upgrade `cachetools` from `>=6,<7` to `>=7,<8` to resolve dependency conflicts with downstream packages that pin `cachetools<7`
- Widen `types-cachetools` upper bound from `<6` to `<7` for compatible type stubs
- Tagged as `v6.1.1`

## Test plan
- [x] All 208 existing tests pass with cachetools 7.0.6
- [x] `uv sync` resolves cleanly