### PR TITLE
Support streamable-http

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This function initializes and starts an MCP server that exposes the kFinance too
 
 The server's full signature is as follows:
 
-`kfinance.mcp [--stdio,-s]/[--sse, ] --refresh-token <refresh-token> --client-id <client-id> --private-key <private-key>`
+`kfinance.mcp [--stdio|-s|--sse|--streamable-http] --refresh-token <refresh-token> --client-id <client-id> --private-key <private-key>`
 
 Authentication Methods (in order of precedence):
 
@@ -49,8 +49,21 @@ Authentication Methods (in order of precedence):
 
 Transport Layers:
 
-- stdio can be set by passing either `--stdio` or `-s`
-- sse can be set by passing `--sse` or no other transport related flag
+- `--stdio` / `-s`: Standard input/output transport (use with MCP Inspector)
+- `--sse`: Server-Sent Events transport (default)
+- `--streamable-http`: HTTP transport
+
+Examples:
+```bash
+# Using stdio with MCP Inspector
+npx @modelcontextprotocol/inspector python -m kfinance.mcp --stdio --refresh-token <token>
+
+# Using SSE (default)
+python -m kfinance.mcp --refresh-token <token>
+
+# Using streamable-http
+python -m kfinance.mcp --streamable-http --refresh-token <token>
+```
 
 # Development
 

--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## v6.1.4
+- Add streamable-http option to local mcp server.
 ## v6.1.3
 - Bump asyncer to 0.0.17
 

--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## v6.1.4
+## v6.2.0
 - Add streamable-http option to local mcp server.
+
 ## v6.1.3
 - Bump asyncer to 0.0.17
 

--- a/kfinance/integrations/local_mcp/local_mcp.py
+++ b/kfinance/integrations/local_mcp/local_mcp.py
@@ -36,12 +36,21 @@ def build_mcp_tool_from_kfinance_tool(kfinance_tool: KfinanceTool) -> FunctionTo
 
 
 @click.command()
-@click.option("--stdio/--sse", "-s/ ", default=False)
+@click.option("--stdio", "-s", "transport", flag_value="stdio", help="Use stdio transport")
+@click.option(
+    "--sse", "transport", flag_value="sse", default=True, help="Use SSE transport (default)"
+)
+@click.option(
+    "--streamable-http",
+    "transport",
+    flag_value="streamable-http",
+    help="Use streamable HTTP transport",
+)
 @click.option("--refresh-token", required=False)
 @click.option("--client-id", required=False)
 @click.option("--private-key", required=False)
 def run_mcp(
-    stdio: bool,
+    transport: Literal["stdio", "sse", "streamable-http"],
     refresh_token: Optional[str] = None,
     client_id: Optional[str] = None,
     private_key: Optional[str] = None,
@@ -57,8 +66,8 @@ def run_mcp(
     2. Key Pair: Uses client ID and private key for authentication
     3. Browser: Falls back to browser-based authentication flow
 
-    :param stdio: If True, use STDIO transport; if False, use SSE transport.
-    :type stdio: bool
+    :param transport: Transport protocol (stdio, sse, or streamable-http).
+    :type transport: Literal["stdio", "sse", "streamable-http"]
     :param refresh_token: OAuth refresh token for authentication
     :type refresh_token: str
     :param client_id: Client id for key-pair authentication
@@ -66,8 +75,7 @@ def run_mcp(
     :param private_key: Private key for key-pair authentication.
     :type private_key: str
     """
-    transport: Literal["stdio", "sse"] = "stdio" if stdio else "sse"
-    logger.info("Sever will run with %s transport", transport)
+    logger.info("Server will run with %s transport", transport)
     if refresh_token:
         logger.info("The client will be authenticated using a refresh token")
         kfinance_client = Client(refresh_token=refresh_token)


### PR DESCRIPTION
Adds streamable-http option (continues using sse as default):

```
python -m kfinance.mcp --streamable-http --refresh-token <token>
python -m kfinance.mcp --sse --refresh-token <token>
python -m kfinance.mcp --stdio --refresh-token <token>

```

Tested locally.