### PR TITLE
Add date range parameter to get_mergers_from_identifiers tool call

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v6.5.0
+- Add date range parameter to support filtering when listing company mergers
+
 ## v6.4.1
 - Change ValidQuarter enum from integer to string for Gemini compatibility
 

--- a/kfinance/client/fetch.py
+++ b/kfinance/client/fetch.py
@@ -724,10 +724,7 @@ class KFinanceApiClient:
         return CompetitorResponse.model_validate(self.fetch(url))
 
     def fetch_mergers_for_company(
-        self,
-        company_id: int,
-        start_date: str | None = None,
-        end_date: str | None = None
+        self, company_id: int, start_date: str | None = None, end_date: str | None = None
     ) -> MergersResp:
         """Fetches the mergers and acquisitions the given company was involved in.
 

--- a/kfinance/client/fetch.py
+++ b/kfinance/client/fetch.py
@@ -726,6 +726,8 @@ class KFinanceApiClient:
     def fetch_mergers_for_company(
         self,
         company_id: int,
+        start_date: str | None = None,
+        end_date: str | None = None
     ) -> MergersResp:
         """Fetches the mergers and acquisitions the given company was involved in.
 
@@ -734,7 +736,9 @@ class KFinanceApiClient:
         :return: A MergersResp, containing transaction IDs, closed_date, and 'merger titles' for each of the three kinds of roles the given company could be party to.
         :rtype: MergersResp
         """
-        url = f"{self.url_base}mergers/{company_id}"
+        start_date_str = start_date if start_date else "none"
+        end_date_str = end_date if end_date else "none"
+        url = f"{self.url_base}mergers/{company_id}/{start_date_str}/{end_date_str}"
         return MergersResp.model_validate(self.fetch(url))
 
     def fetch_merger_info(

--- a/kfinance/client/kfinance.py
+++ b/kfinance/client/kfinance.py
@@ -644,15 +644,34 @@ class Company(CompanyFunctionsMetaClass):
                 )
             self._mergers_for_company = output
         return self._mergers_for_company
-    
-    def mergers_and_acquisitions_within_dates(self, start_date: date | None, end_date: date | None) -> dict[str, MergersAndAcquisitions]:
+
+    def mergers_and_acquisitions_within_dates(
+        self, start_date: date | None, end_date: date | None
+    ) -> dict[str, MergersAndAcquisitions]:
+        """Get the merger and acquisitions this company has been party to, within the specified date range.
+
+        If a start_date and/or end_date is specified, only mergers where the merger
+        timeline intersects with the date range are returned. The merger timeline is
+        considered to be from the earliest event associated with the merger to
+        the latest event. If any date between (and inclusive of) these two event dates
+        falls within the passed-in date range, the merger is returned. If only an
+        announcement date is found for a merger, the merger timeline is taken to be
+        until the earlier of the current date or 10 years after the announcement date.
+
+        :param start_date: The start date for the date range filter.
+        :type start_date: date, optional
+        :param end_date: The end date for the date range filter.
+        :type end_date: date, optional
+        :return: three lists of transactions, one each for 'target', 'buyer', and 'seller'
+        :rtype: dict[str, MergersAndAcquisitions]
+        """
         if start_date is None and end_date is not None:
             return self.mergers_and_acquisitions
-        
+
         # We can't use self.mergers_and_acquisitions here. The date range filter
-        # on the server side checks for any event associated with a merger that
-        # falls within the date range. We only fetch closed_date from the server
-        # so we cannot do this filtering ourselves and need to refetch from the server.
+        # on the server side requires all events associated with a merger.
+        # We only fetch closed_date from the server, so we cannot do this filtering
+        # ourselves.
         mergers = self.kfinance_api_client.fetch_mergers_for_company(
             company_id=self.company_id,
             start_date=start_date.isoformat() if start_date else None,
@@ -661,9 +680,7 @@ class Company(CompanyFunctionsMetaClass):
 
         output: dict[str, MergersAndAcquisitions] = {}
         for literal in ["target", "buyer", "seller"]:
-            output[literal] = MergersAndAcquisitions(
-                self.kfinance_api_client, mergers[literal]
-            )
+            output[literal] = MergersAndAcquisitions(self.kfinance_api_client, mergers[literal])
         return output
 
     @property

--- a/kfinance/client/kfinance.py
+++ b/kfinance/client/kfinance.py
@@ -644,6 +644,27 @@ class Company(CompanyFunctionsMetaClass):
                 )
             self._mergers_for_company = output
         return self._mergers_for_company
+    
+    def mergers_and_acquisitions_within_dates(self, start_date: date | None, end_date: date | None) -> dict[str, MergersAndAcquisitions]:
+        if start_date is None and end_date is not None:
+            return self.mergers_and_acquisitions
+        
+        # We can't use self.mergers_and_acquisitions here. The date range filter
+        # on the server side checks for any event associated with a merger that
+        # falls within the date range. We only fetch closed_date from the server
+        # so we cannot do this filtering ourselves and need to refetch from the server.
+        mergers = self.kfinance_api_client.fetch_mergers_for_company(
+            company_id=self.company_id,
+            start_date=start_date.isoformat() if start_date else None,
+            end_date=end_date.isoformat() if end_date else None,
+        ).model_dump(mode="json")
+
+        output: dict[str, MergersAndAcquisitions] = {}
+        for literal in ["target", "buyer", "seller"]:
+            output[literal] = MergersAndAcquisitions(
+                self.kfinance_api_client, mergers[literal]
+            )
+        return output
 
     @property
     def rounds_of_funding(self) -> RoundsOfFunding:

--- a/kfinance/client/tests/test_fetch.py
+++ b/kfinance/client/tests/test_fetch.py
@@ -383,10 +383,20 @@ class TestFetchItem(TestCase):
 
     def test_fetch_mergers_for_company(self) -> None:
         company_id = 21719
-        expected_fetch_url = f"{self.kfinance_api_client.url_base}mergers/{company_id}"
+        expected_fetch_url = f"{self.kfinance_api_client.url_base}mergers/{company_id}/none/none"
         # Validation error is ok, we only care that the function was called with the correct url
         with pytest.raises(ValidationError):
             self.kfinance_api_client.fetch_mergers_for_company(company_id=company_id)
+        self.kfinance_api_client.fetch.assert_called_with(expected_fetch_url)
+    
+    def test_fetch_mergers_with_date_range_for_company(self) -> None:
+        company_id = 21719
+        start_date = '2020-01-01'
+        end_date = '2022-09-31'
+        expected_fetch_url = f"{self.kfinance_api_client.url_base}mergers/{company_id}/{start_date}/{end_date}"
+        # Validation error is ok, we only care that the function was called with the correct url
+        with pytest.raises(ValidationError):
+            self.kfinance_api_client.fetch_mergers_for_company(company_id=company_id, start_date=start_date, end_date=end_date)
         self.kfinance_api_client.fetch.assert_called_with(expected_fetch_url)
 
     def test_fetch_merger_info(self) -> None:

--- a/kfinance/client/tests/test_fetch.py
+++ b/kfinance/client/tests/test_fetch.py
@@ -388,15 +388,19 @@ class TestFetchItem(TestCase):
         with pytest.raises(ValidationError):
             self.kfinance_api_client.fetch_mergers_for_company(company_id=company_id)
         self.kfinance_api_client.fetch.assert_called_with(expected_fetch_url)
-    
+
     def test_fetch_mergers_with_date_range_for_company(self) -> None:
         company_id = 21719
-        start_date = '2020-01-01'
-        end_date = '2022-09-31'
-        expected_fetch_url = f"{self.kfinance_api_client.url_base}mergers/{company_id}/{start_date}/{end_date}"
+        start_date = "2020-01-01"
+        end_date = "2022-09-31"
+        expected_fetch_url = (
+            f"{self.kfinance_api_client.url_base}mergers/{company_id}/{start_date}/{end_date}"
+        )
         # Validation error is ok, we only care that the function was called with the correct url
         with pytest.raises(ValidationError):
-            self.kfinance_api_client.fetch_mergers_for_company(company_id=company_id, start_date=start_date, end_date=end_date)
+            self.kfinance_api_client.fetch_mergers_for_company(
+                company_id=company_id, start_date=start_date, end_date=end_date
+            )
         self.kfinance_api_client.fetch.assert_called_with(expected_fetch_url)
 
     def test_fetch_merger_info(self) -> None:

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
@@ -63,7 +63,7 @@ class GetMergersFromIdentifiers(KfinanceTool):
 
         Query: "Get acquisitions for AAPL and GOOGL"
         Function: get_mergers_from_identifiers(identifiers=["AAPL", "GOOGL"])
-                              
+
         Query: "What companies was Apple selling between 2019 and 2022?"
         Function: get_mergers_from_identifiers(identifiers=["Apple"], start_date="2019-01-01", end_date="2022-12-31")
     """).strip()

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
@@ -24,11 +24,11 @@ from kfinance.integrations.tool_calling.tool_calling_models import (
 
 class GetMergersFromIdentifiersArgs(ToolArgsWithIdentifiers):
     start_date: date | None = Field(
-        description="The start date fo",
+        description="The start date for merger date-range filtering. Use null for all mergers.",
         default=None,
     )
     end_date: date | None = Field(
-        description="Bababaa",
+        description="The end date for merge date-range filtering. Use null for all mergers.",
         default=None,
     )
 
@@ -42,9 +42,19 @@ class GetMergersFromIdentifiers(KfinanceTool):
     description: str = dedent("""
         Retrieves all merger and acquisition transactions involving the specified company.
 
+        If a start_date and/or end_date is specified, only mergers where the merger
+        timeline intersects with the date range are returned. The merger timeline is
+        considered to be from the earliest event associated with the merger to
+        the latest event. If any date between (and inclusive of) these two event dates
+        falls within the passed-in date range, the merger is returned. If only an
+        announcement date is found for a merger, the merger timeline is taken to be
+        until the earlier of the current date or 10 years after the announcement date.
+
         Results are categorized by the company's role: target (being acquired), buyer (making the acquisition), or seller (divesting an asset).
 
         - When possible, pass multiple identifiers in a single call rather than making multiple calls.
+        - When requesting all mergers, leave start_date and end_date null.
+        - Only specify date ranges when the user explicitly requests mergers and acquisitions during some date range.
         - Provides transaction_id, merger_title, and transaction closed_date.
 
         Examples:
@@ -53,6 +63,9 @@ class GetMergersFromIdentifiers(KfinanceTool):
 
         Query: "Get acquisitions for AAPL and GOOGL"
         Function: get_mergers_from_identifiers(identifiers=["AAPL", "GOOGL"])
+                              
+        Query: "What companies was Apple selling between 2019 and 2022?"
+        Function: get_mergers_from_identifiers(identifiers=["Apple"], start_date="2019-01-01", end_date="2022-12-31")
     """).strip()
     args_schema: Type[BaseModel] = GetMergersFromIdentifiersArgs
     accepted_permissions: set[Permission] | None = {Permission.MergersPermission}

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
@@ -28,7 +28,7 @@ class GetMergersFromIdentifiersArgs(ToolArgsWithIdentifiers):
         default=None,
     )
     end_date: date | None = Field(
-        description="The end date for merge date-range filtering. Use null for all mergers.",
+        description="The end date for merger date-range filtering. Use null for all mergers.",
         default=None,
     )
 

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
@@ -1,3 +1,4 @@
+from datetime import date
 from textwrap import dedent
 from typing import Type
 
@@ -21,6 +22,17 @@ from kfinance.integrations.tool_calling.tool_calling_models import (
 )
 
 
+class GetMergersFromIdentifiersArgs(ToolArgsWithIdentifiers):
+    start_date: date | None = Field(
+        description="The start date fo",
+        default=None,
+    )
+    end_date: date | None = Field(
+        description="Bababaa",
+        default=None,
+    )
+
+
 class GetMergersFromIdentifiersResp(ToolRespWithIdInfoAndErrors[MergersResp]):
     pass
 
@@ -42,13 +54,17 @@ class GetMergersFromIdentifiers(KfinanceTool):
         Query: "Get acquisitions for AAPL and GOOGL"
         Function: get_mergers_from_identifiers(identifiers=["AAPL", "GOOGL"])
     """).strip()
-    args_schema: Type[BaseModel] = ToolArgsWithIdentifiers
+    args_schema: Type[BaseModel] = GetMergersFromIdentifiersArgs
     accepted_permissions: set[Permission] | None = {Permission.MergersPermission}
 
-    async def _arun(self, identifiers: list[str]) -> GetMergersFromIdentifiersResp:
+    async def _arun(
+        self, identifiers: list[str], start_date: date | None = None, end_date: date | None = None
+    ) -> GetMergersFromIdentifiersResp:
         """"""
         return await get_mergers_from_identifiers(
             identifiers=identifiers,
+            start_date=start_date,
+            end_date=end_date,
             httpx_client=self.kfinance_client.httpx_client,
         )
 
@@ -127,6 +143,8 @@ class GetAdvisorsForCompanyInTransactionFromIdentifier(KfinanceTool):
 async def get_mergers_from_identifiers(
     identifiers: list[str],
     httpx_client: httpx.AsyncClient,
+    start_date: date | None = None,
+    end_date: date | None = None,
 ) -> GetMergersFromIdentifiersResp:
     """Fetch mergers for all identifiers."""
 
@@ -140,6 +158,8 @@ async def get_mergers_from_identifiers(
             func=fetch_mergers_from_company_id,
             kwargs=dict(
                 company_id=id_triple.company_id,
+                start_date=start_date,
+                end_date=end_date,
                 httpx_client=httpx_client,
             ),
             result_key=identifier,
@@ -166,9 +186,14 @@ async def get_mergers_from_identifiers(
 async def fetch_mergers_from_company_id(
     company_id: int,
     httpx_client: httpx.AsyncClient,
+    start_date: date | None = None,
+    end_date: date | None = None,
 ) -> MergersResp:
     """Fetch mergers for one company_id."""
-    url = f"/mergers/{company_id}"
+    start_date_str = start_date.isoformat() if start_date else "none"
+    end_date_str = end_date.isoformat() if end_date else "none"
+
+    url = f"/mergers/{company_id}/{start_date_str}/{end_date_str}"
     resp = await httpx_client.get(url=url)
     resp.raise_for_status()
     return MergersResp.model_validate(resp.json())

--- a/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from datetime import date
 
 import httpx
 import pytest
@@ -12,6 +13,7 @@ from kfinance.conftest import SPGI_ID_TRIPLE
 from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_models import (
     AdvisorResp,
     MergerInfo,
+    MergersResp,
 )
 from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_tools import (
     GetAdvisorsForCompanyInTransactionFromIdentifierResp,
@@ -52,6 +54,39 @@ class TestMergersAndAcquisitions:
         )
 
         expected_resp = MERGERS_RESP
+        assert resp == expected_resp
+
+    @pytest.mark.asyncio
+    async def test_fetch_mergers_from_company_id_with_date_range(
+        self, httpx_client: httpx.AsyncClient, httpx_mock: HTTPXMock
+    ) -> None:
+        """
+        WHEN we request SPGI's mergers for a specific date range,
+        THEN we get back only those mergers
+        """
+        start_date = date(2022, 1, 1)
+        end_date = date(2024, 5, 1)
+
+        # We're just using a different response than the previous test here - the actual filtering doesn't matter.
+        expected_resp = MergersResp(
+            target=[MERGERS_RESP.target[0]],
+            buyer=[MERGERS_RESP.buyer[0]],
+            seller=[MERGERS_RESP.seller[0]],
+        )
+
+        httpx_mock.add_response(
+            method="GET",
+            url=f"https://kfinance.kensho.com/api/v1/mergers/{SPGI_ID_TRIPLE.company_id}/{start_date.isoformat()}/{end_date.isoformat()}",
+            json=expected_resp.model_dump(mode="json", by_alias=True),
+        )
+
+        resp = await fetch_mergers_from_company_id(
+            company_id=SPGI_ID_TRIPLE.company_id,
+            httpx_client=httpx_client,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
         assert resp == expected_resp
 
     @pytest.mark.asyncio

--- a/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
@@ -30,7 +30,7 @@ class TestMergersAndAcquisitions:
         merger_data = MERGERS_RESP.model_dump(mode="json")
         httpx_mock.add_response(
             method="GET",
-            url=f"https://kfinance.kensho.com/api/v1/mergers/{SPGI_ID_TRIPLE.company_id}",
+            url=f"https://kfinance.kensho.com/api/v1/mergers/{SPGI_ID_TRIPLE.company_id}/none/none",
             json=merger_data,
             is_optional=True,
         )


### PR DESCRIPTION
We recently updated the API to accept a date range for filtering company mergers. In this PR, we update the tool calls and client to accept the date range. Updates to the tool descriptions will follow soon.