### PR TITLE
Fix gemini enum issue

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v6.2.2
+- Change ValidQuarter enum from integer to string for Gemini compatibility
+
 ## v6.2.1
 - Add streamable-http option to local mcp server.
 

--- a/kfinance/integrations/tool_calling/tool_calling_models.py
+++ b/kfinance/integrations/tool_calling/tool_calling_models.py
@@ -5,6 +5,7 @@ from asyncer import syncify
 from httpx import HTTPStatusError
 from langchain_core.tools import BaseTool
 from pydantic import (
+    AfterValidator,
     BaseModel,
     BeforeValidator,
     ConfigDict,
@@ -159,12 +160,24 @@ def convert_str_to_int(v: Any) -> Any:
     return v
 
 
-# Valid Quarter is a literal type, which converts strings to int before
-# validating them.
-# Claude seems to often pass strings to int literals, which raise a
-# ValidationError during deserialization unless they have been converted
-# to int.
-ValidQuarter = Annotated[Literal[1, 2, 3, 4], BeforeValidator(convert_str_to_int)]
+def convert_int_to_str(v: Any) -> Any:
+    """Convert integers to strings if possible."""
+    if isinstance(v, int):
+        return str(v)
+    return v
+
+
+# ValidQuarter is a string literal type. Gemini throws 500 internal error on int enum values.
+# Support ticket: https://console.cloud.google.com/support/cases/detail/v2/70990622?project=kensho-groundings-poc
+# Claude seems to often pass integers to enum fields, which raise a ValidationError
+# during deserialization unless they have been converted to str.
+# BeforeValidator: convert possible int to str before Literal validation.
+# AfterValidator: convert str back to int to stay consistent with internal kfinance logic.
+ValidQuarter = Annotated[
+    Literal["1", "2", "3", "4"],
+    BeforeValidator(convert_int_to_str),
+    AfterValidator(convert_str_to_int),
+]
 
 
 class ToolRespWithErrors(BaseModel):

--- a/kfinance/integrations/tool_calling/tool_calling_models.py
+++ b/kfinance/integrations/tool_calling/tool_calling_models.py
@@ -171,6 +171,8 @@ def convert_int_to_str(v: Any) -> Any:
 # Support ticket: https://console.cloud.google.com/support/cases/detail/v2/70990622?project=kensho-groundings-poc
 # Claude seems to often pass integers to enum fields, which raise a ValidationError
 # during deserialization unless they have been converted to str.
+
+# TODO(LRA-304): Revert following fix after Gemini schema leniency feature is implemented.
 # BeforeValidator: convert possible int to str before Literal validation.
 # AfterValidator: convert str back to int to stay consistent with internal kfinance logic.
 ValidQuarter = Annotated[


### PR DESCRIPTION
### Notes

Fixed the Gemini Enterprise `500` internal error when calling LRA MCP tools. Gemini is very strict on tools schema and requires enum literal to use `string` value. Here is suggestion from Google in the [support ticket](https://console.cloud.google.com/support/cases/detail/v2/70990622).

> For the first error, yes, please first update the enum definitions that currently use integer values, such as start_quarter, so the exposed MCP tool schema uses string enum values instead. For example, change values like [1, 2, 3, 4] to ["1", "2", "3", "4"].

This PR uses before/after model validator to ensure it can account for possible int/string input and still pass down `int` value to internal process, keeping consistent with existing logic. After the change, only those `quarter` fields are updated to enum string like example below.

<img width="804" height="287" alt="Screenshot 2026-05-21 at 10 48 08 AM" src="https://github.com/user-attachments/assets/637b81e6-a968-4eaa-a45d-16a14449f376" />


### Testing

1. Compared old and new tools schema and only expected `quarter` fields are changed.
2. Ran local MCP server and tested the 5 affected tools manually. They work as expected.
3. Deployed server to `preview` environment and tested in Gemini Enterprise. Manually tested query and did not observe any `500` internal error. The returned data is retrieved from connected LRA MCP (`Preview` environment).

<img width="942" height="686" alt="Screenshot 2026-05-21 at 11 12 27 AM" src="https://github.com/user-attachments/assets/913dde1b-a8d0-49cc-b898-129d3b085e18" />

