### PR TITLE
Add more information to mergers list tool, and replace merger info tool with batch version

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -6,10 +6,13 @@
 - Replace merger info tool call with a batch version named `get_mergers_info_from_transaction_ids`,
   which also supports the option of including advisors in the response
 - Breaking changes:
+- Remove `get_advisors_for_company_in_transaction_from_identifier` tool, since it is redundant with
+  the `include_advisors` parameter on `get_mergers_info_from_transaction_ids`.
   - `merger_title` field has been removed from the `MergerOrAcquisition` object
   type and the `MergerSummary` type, since the newly added fields make that field
   redundant.
   - `get_merger_info_from_transaction_id` tool call has been removed.
+  - `get_advisors_for_company_in_transaction_from_identifier` tool call has been removed.
 
 ## v6.6.2
 - Split GetEstimatesFromIdentifiersResp into CIQ and VA variants

--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v7.0.0
-- Include additional information in get_mergers_from_identifiers tool call response
+- Include additional information in `get_mergers_from_identifiers` tool call response and `MergerOrAcquisition` object.
 - Replace merger info tool call with a batch version named `get_mergers_info_from_transaction_ids`
 - Breaking changes:
   - `merger_title` field has been removed from the `MergerOrAcquisition` object

--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v7.0.0
+- Include additional information in get_mergers_from_identifiers tool call response
+- Replace merger info tool call with a batch version, called get_mergers_info_from_transaction_ids
+- Breaking changes:
+  - `merger_title` field has been removed from the `MergerOrAcquisition` object
+  type and the `MergerSummary` type, since the newly added fields make that field
+  redundant.
+  - `get_merger_info_from_transaction_id` tool call has been removed.
+
 ## v6.5.1
 - Change M&A tool descriptions and prompts.py for M&A performance improvement
 

--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## v7.0.0
 - Include `status`, `start_date`, `target`, and `buyers` fields in `get_mergers_from_identifiers` 
   tool call response and `MergerOrAcquisition` object.
-- Replace merger info tool call with a batch version named `get_mergers_info_from_transaction_ids`
+- Replace merger info tool call with a batch version named `get_mergers_info_from_transaction_ids`,
+  which also supports the option of including advisors in the response
 - Breaking changes:
   - `merger_title` field has been removed from the `MergerOrAcquisition` object
   type and the `MergerSummary` type, since the newly added fields make that field

--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v7.0.0
 - Include additional information in get_mergers_from_identifiers tool call response
-- Replace merger info tool call with a batch version, called get_mergers_info_from_transaction_ids
+- Replace merger info tool call with a batch version named `get_mergers_info_from_transaction_ids`
 - Breaking changes:
   - `merger_title` field has been removed from the `MergerOrAcquisition` object
   type and the `MergerSummary` type, since the newly added fields make that field

--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## v7.0.0
-- Include additional information in `get_mergers_from_identifiers` tool call response and `MergerOrAcquisition` object.
+- Include `status`, `start_date`, `target`, and `buyers` fields in `get_mergers_from_identifiers` 
+  tool call response and `MergerOrAcquisition` object.
 - Replace merger info tool call with a batch version named `get_mergers_info_from_transaction_ids`
 - Breaking changes:
   - `merger_title` field has been removed from the `MergerOrAcquisition` object

--- a/kfinance/client/fetch.py
+++ b/kfinance/client/fetch.py
@@ -40,7 +40,7 @@ from kfinance.domains.estimates.estimates_models import (
 from kfinance.domains.key_developments.key_devs_models import KeyDevCategoryType, KeyDevsResp
 from kfinance.domains.line_items.line_item_models import CalendarType, LineItemResp
 from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_models import (
-    MergerInfo,
+    MergersInfo,
     MergersResp,
 )
 from kfinance.domains.prices.price_models import HistoryMetadataResp, PriceHistory
@@ -763,10 +763,9 @@ class KFinanceApiClient:
         url = f"{self.url_base}mergers/{company_id}/{start_date_str}/{end_date_str}"
         return MergersResp.model_validate(self.fetch(url))
 
-    def fetch_merger_info(
-        self,
-        transaction_id: int,
-    ) -> MergerInfo:
+    def fetch_mergers_info(
+        self, transaction_ids: list[int], include_advisors: bool = False
+    ) -> MergersInfo:
         """Fetches information about the given merger or acquisition, including the timeline, the participants, and the considerations.
 
         :param transaction_id: The transaction ID to filter on.
@@ -774,8 +773,10 @@ class KFinanceApiClient:
         :return: A dictionary containing the timeline, the participants, and the considerations (eith their details) of the transaction.
         :rtype: MergerInfo
         """
-        url = f"{self.url_base}merger/info/{transaction_id}"
-        return MergerInfo.model_validate(self.fetch(url))
+        url = f"{self.url_base}mergers/info"
+        request_body = {"transaction_ids": transaction_ids, "include_advisors": include_advisors}
+
+        return MergersInfo.model_validate(self.fetch(url, method="POST", request_body=request_body))
 
     def fetch_advisors_for_company_in_merger(
         self,

--- a/kfinance/client/fetch.py
+++ b/kfinance/client/fetch.py
@@ -755,6 +755,10 @@ class KFinanceApiClient:
 
         :param company_id: The company ID to filter on.
         :type company_id: int
+        :param start_date: The start date to filter mergers on.
+        :type start_date: str | None
+        :param end_date: The end date to filter mergers on.
+        :type end_date: str | None
         :return: A MergersResp, containing transaction IDs, closed_date, and 'merger titles' for each of the three kinds of roles the given company could be party to.
         :rtype: MergersResp
         """
@@ -766,10 +770,12 @@ class KFinanceApiClient:
     def fetch_mergers_info(
         self, transaction_ids: list[int], include_advisors: bool = False
     ) -> MergersInfo:
-        """Fetches information about the given merger or acquisition, including the timeline, the participants, and the considerations.
+        """Fetches information about the given mergers or acquisitions, including the timeline, the participants, and the considerations.
 
-        :param transaction_id: The transaction ID to filter on.
-        :type transaction_id: int
+        :param transaction_ids: The transaction IDs to filter on.
+        :type transaction_ids: list[int]
+        :param include_advisors: Whether to include advisors for participants.
+        :type include_advisors: bool
         :return: A dictionary containing the timeline, the participants, and the considerations (eith their details) of the transaction.
         :rtype: MergerInfo
         """

--- a/kfinance/client/kfinance.py
+++ b/kfinance/client/kfinance.py
@@ -1480,8 +1480,12 @@ class MergerOrAcquisition:
         self,
         kfinance_api_client: KFinanceApiClient,
         transaction_id: int,
+        status: str,
         merger_title: str | None,
+        start_date: date | None,
         closed_date: date | None,
+        target: str,
+        buyers: list[str],
     ) -> None:
         """MergerOrAcqusition initializer.
 
@@ -1491,15 +1495,26 @@ class MergerOrAcquisition:
         """
         self.kfinance_api_client = kfinance_api_client
         self.transaction_id = transaction_id
+        self.status = status
         self.merger_title = merger_title
+        self.start_date = start_date
         self.closed_date = closed_date
+        self.target = target
+        self.buyers = buyers
         self._merger_info: MergerInfo | None = None
 
     @property
     def merger_info(self) -> MergerInfo:
         """Property for the combined information in the merger."""
         if not self._merger_info:
-            self._merger_info = self.kfinance_api_client.fetch_merger_info(self.transaction_id)
+            merger_info = self.kfinance_api_client.fetch_mergers_info(
+                [self.transaction_id]
+            ).results[self.transaction_id]
+            if not isinstance(merger_info, MergerInfo):
+                raise ValueError(
+                    f"No information for merger with transaction ID {self.transaction_id}"
+                )
+            self._merger_info = merger_info
         return self._merger_info
 
     @property
@@ -1741,8 +1756,12 @@ class MergersAndAcquisitions(set):
             MergerOrAcquisition(
                 kfinance_api_client=kfinance_api_client,
                 transaction_id=id_and_title["transaction_id"],
+                status=id_and_title["status"],
                 merger_title=id_and_title["merger_title"],
+                start_date=id_and_title["start_date"],
                 closed_date=id_and_title["closed_date"],
+                target=id_and_title["target"],
+                buyers=id_and_title["buyers"],
             )
             for id_and_title in ids_and_titles
         )

--- a/kfinance/client/kfinance.py
+++ b/kfinance/client/kfinance.py
@@ -1481,7 +1481,6 @@ class MergerOrAcquisition:
         kfinance_api_client: KFinanceApiClient,
         transaction_id: int,
         status: str,
-        merger_title: str | None,
         start_date: date | None,
         closed_date: date | None,
         target: str,
@@ -1496,7 +1495,6 @@ class MergerOrAcquisition:
         self.kfinance_api_client = kfinance_api_client
         self.transaction_id = transaction_id
         self.status = status
-        self.merger_title = merger_title
         self.start_date = start_date
         self.closed_date = closed_date
         self.target = target
@@ -1516,11 +1514,6 @@ class MergerOrAcquisition:
                 )
             self._merger_info = merger_info
         return self._merger_info
-
-    @property
-    def get_merger_title(self) -> str | None:
-        """The merger title includes the status of the merger and its target."""
-        return self.merger_title
 
     @property
     def get_timeline(self) -> list[MergerTimelineElement]:
@@ -1757,7 +1750,6 @@ class MergersAndAcquisitions(set):
                 kfinance_api_client=kfinance_api_client,
                 transaction_id=id_and_title["transaction_id"],
                 status=id_and_title["status"],
-                merger_title=id_and_title["merger_title"],
                 start_date=id_and_title["start_date"],
                 closed_date=id_and_title["closed_date"],
                 target=id_and_title["target"],

--- a/kfinance/client/tests/test_fetch.py
+++ b/kfinance/client/tests/test_fetch.py
@@ -417,15 +417,6 @@ class TestFetchItem(TestCase):
             expected_fetch_url, method="POST", request_body=expected_request_body
         )
 
-    def test_fetch_advisors_for_company_in_merger(self) -> None:
-        transaction_id = 554979212
-        advised_company_id = 251994106
-        expected_fetch_url = f"{self.kfinance_api_client.url_base}merger/info/{transaction_id}/advisors/{advised_company_id}"
-        self.kfinance_api_client.fetch_advisors_for_company_in_merger(
-            transaction_id=transaction_id, advised_company_id=advised_company_id
-        )
-        self.kfinance_api_client.fetch.assert_called_with(expected_fetch_url)
-
     def test_fetch_estimate(self) -> None:
         company_id = 21719
         estimate_type = "consensus"

--- a/kfinance/client/tests/test_fetch.py
+++ b/kfinance/client/tests/test_fetch.py
@@ -404,13 +404,18 @@ class TestFetchItem(TestCase):
             )
         self.kfinance_api_client.fetch.assert_called_with(expected_fetch_url)
 
-    def test_fetch_merger_info(self) -> None:
+    def test_fetch_mergers_info(self) -> None:
         transaction_id = 554979212
-        expected_fetch_url = f"{self.kfinance_api_client.url_base}merger/info/{transaction_id}"
+        expected_fetch_url = f"{self.kfinance_api_client.url_base}mergers/info"
+        expected_request_body = {"transaction_ids": [transaction_id], "include_advisors": True}
         # Validation error is ok, we only care that the function was called with the correct url
         with pytest.raises(ValidationError):
-            self.kfinance_api_client.fetch_merger_info(transaction_id=transaction_id)
-        self.kfinance_api_client.fetch.assert_called_with(expected_fetch_url)
+            self.kfinance_api_client.fetch_mergers_info(
+                transaction_ids=[transaction_id], include_advisors=True
+            )
+        self.kfinance_api_client.fetch.assert_called_with(
+            expected_fetch_url, method="POST", request_body=expected_request_body
+        )
 
     def test_fetch_advisors_for_company_in_merger(self) -> None:
         transaction_id = 554979212

--- a/kfinance/client/tests/test_objects.py
+++ b/kfinance/client/tests/test_objects.py
@@ -333,7 +333,6 @@ MERGERS_RESP = MergersResp.model_validate(
         "target": [
             {
                 "transaction_id": 0,
-                "merger_title": "Closed M/A of Microsoft Corporation",
                 "status": "Closed",
                 "start_date": "2021-01-01",
                 "closed_date": "2021-01-01",
@@ -344,7 +343,6 @@ MERGERS_RESP = MergersResp.model_validate(
         "buyer": [
             {
                 "transaction_id": 517414,
-                "merger_title": "Closed M/A of MongoMusic, Inc.",
                 "status": "Closed",
                 "start_date": "2000-09-12",
                 "closed_date": "2000-09-12",
@@ -353,7 +351,6 @@ MERGERS_RESP = MergersResp.model_validate(
             },
             {
                 "transaction_id": 596722,
-                "merger_title": "Closed M/A of Digital Anvil, Inc.",
                 "status": "Closed",
                 "start_date": "2000-12-05",
                 "closed_date": "2000-12-05",
@@ -364,7 +361,6 @@ MERGERS_RESP = MergersResp.model_validate(
         "seller": [
             {
                 "transaction_id": 455551,
-                "merger_title": "Closed M/A of VacationSpot.com, Inc.",
                 "status": "Closed",
                 "start_date": "2000-01-30",
                 "closed_date": "2000-03-17",
@@ -373,7 +369,6 @@ MERGERS_RESP = MergersResp.model_validate(
             },
             {
                 "transaction_id": 456045,
-                "merger_title": "Closed M/A of TransPoint, LLC",
                 "status": "Closed",
                 "start_date": "2000-02-15",
                 "closed_date": "2000-09-05",
@@ -851,7 +846,6 @@ class TestCompany(TestCase):
                 {
                     "transaction_id": merger.transaction_id,
                     "status": merger.status,
-                    "merger_title": merger.merger_title,
                     "start_date": merger.start_date,
                     "closed_date": merger.closed_date,
                     "target": merger.target,
@@ -863,7 +857,6 @@ class TestCompany(TestCase):
                 {
                     "transaction_id": merger.transaction_id,
                     "status": merger.status,
-                    "merger_title": merger.merger_title,
                     "start_date": merger.start_date,
                     "closed_date": merger.closed_date,
                     "target": merger.target,
@@ -875,7 +868,6 @@ class TestCompany(TestCase):
                 {
                     "transaction_id": merger.transaction_id,
                     "status": merger.status,
-                    "merger_title": merger.merger_title,
                     "start_date": merger.start_date,
                     "closed_date": merger.closed_date,
                     "target": merger.target,

--- a/kfinance/client/tests/test_objects.py
+++ b/kfinance/client/tests/test_objects.py
@@ -38,6 +38,7 @@ from kfinance.domains.estimates.estimates_models import (
 from kfinance.domains.line_items.line_item_models import LineItemResp
 from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_models import (
     MergerInfo,
+    MergersInfo,
     MergersResp,
 )
 from kfinance.domains.prices.price_models import HistoryMetadataResp
@@ -331,38 +332,53 @@ MERGERS_RESP = MergersResp.model_validate(
     {
         "target": [
             {
-                "transaction_id": 10998717,
+                "transaction_id": 0,
                 "merger_title": "Closed M/A of Microsoft Corporation",
+                "status": "Closed",
+                "start_date": "2021-01-01",
                 "closed_date": "2021-01-01",
-            },
-            {
-                "transaction_id": 28237969,
-                "merger_title": "Closed M/A of Microsoft Corporation",
-                "closed_date": "2022-01-01",
+                "target": "Microsoft Corporation",
+                "buyers": [],
             },
         ],
         "buyer": [
             {
                 "transaction_id": 517414,
                 "merger_title": "Closed M/A of MongoMusic, Inc.",
-                "closed_date": "2023-01-01",
+                "status": "Closed",
+                "start_date": "2000-09-12",
+                "closed_date": "2000-09-12",
+                "target": "MongoMusic, Inc.",
+                "buyers": ["Microsoft Corporation"],
             },
             {
                 "transaction_id": 596722,
                 "merger_title": "Closed M/A of Digital Anvil, Inc.",
-                "closed_date": "2023-01-01",
+                "status": "Closed",
+                "start_date": "2000-12-05",
+                "closed_date": "2000-12-05",
+                "target": "Digital Anvil, Inc.",
+                "buyers": ["Microsoft Corporation"],
             },
         ],
         "seller": [
             {
                 "transaction_id": 455551,
                 "merger_title": "Closed M/A of VacationSpot.com, Inc.",
-                "closed_date": "2024-01-01",
+                "status": "Closed",
+                "start_date": "2000-01-30",
+                "closed_date": "2000-03-17",
+                "target": "VacationSpot.com, Inc.",
+                "buyers": ["Expedia, Inc."],
             },
             {
                 "transaction_id": 456045,
                 "merger_title": "Closed M/A of TransPoint, LLC",
-                "closed_date": "2025-01-01",
+                "status": "Closed",
+                "start_date": "2000-02-15",
+                "closed_date": "2000-09-05",
+                "target": "TransPoint, LLC",
+                "buyers": ["CheckFree Corp."],
             },
         ],
     }
@@ -388,15 +404,33 @@ MOCK_MERGERS_DB = {
                 {"status": "Closed", "date": "2000-09-12"},
             ],
             "participants": {
-                "target": {"company_id": 31696, "company_name": "MongoMusic, Inc."},
-                "buyers": [{"company_id": 21835, "company_name": "Microsoft Corporation"}],
+                "target": {
+                    "company_id": 31696,
+                    "company_name": "MongoMusic, Inc.",
+                    "advisors": None,
+                },
+                "buyers": [
+                    {"company_id": 21835, "company_name": "Microsoft Corporation", "advisors": None}
+                ],
                 "sellers": [
-                    {"company_id": 18805, "company_name": "Angel Investors L.P."},
-                    {"company_id": 20087, "company_name": "Draper Richards, L.P."},
-                    {"company_id": 22103, "company_name": "BRV Partners, LLC"},
-                    {"company_id": 23745, "company_name": "Venture Frogs, LLC"},
-                    {"company_id": 105902, "company_name": "ARGUS Capital International Limited"},
-                    {"company_id": 880300, "company_name": "Sony Music Entertainment, Inc."},
+                    {"company_id": 18805, "company_name": "Angel Investors L.P.", "advisors": None},
+                    {
+                        "company_id": 20087,
+                        "company_name": "Draper Richards, L.P.",
+                        "advisors": None,
+                    },
+                    {"company_id": 22103, "company_name": "BRV Partners, LLC", "advisors": None},
+                    {"company_id": 23745, "company_name": "Venture Frogs, LLC", "advisors": None},
+                    {
+                        "company_id": 105902,
+                        "company_name": "ARGUS Capital International Limited",
+                        "advisors": None,
+                    },
+                    {
+                        "company_id": 880300,
+                        "company_name": "Sony Music Entertainment, Inc.",
+                        "advisors": None,
+                    },
                 ],
             },
             "consideration": {
@@ -579,11 +613,21 @@ class MockKFinanceApiClient:
         """Get the transcript for an earnings item."""
         return MOCK_TRANSCRIPT_DB[key_dev_id]
 
-    def fetch_mergers_for_company(self, company_id):
+    def fetch_mergers_for_company(self, company_id: int) -> MergersResp:
         return copy.deepcopy(MERGERS_RESP)
 
-    def fetch_merger_info(self, transaction_id: int):
-        return copy.deepcopy(MOCK_MERGERS_DB[str(transaction_id)])
+    def fetch_mergers_info(
+        self, transaction_ids: list[int], include_advisors: bool = False
+    ) -> MergersInfo:
+        return MergersInfo.model_validate(
+            {
+                "results": {
+                    transaction_id: info
+                    for transaction_id, info in MOCK_MERGERS_DB.items()
+                    if transaction_id in transaction_ids
+                }
+            }
+        )
 
     def fetch_advisors_for_company_in_merger(self, transaction_id, advised_company_id):
         return copy.deepcopy(MOCK_COMPANY_DB[advised_company_id]["advisors"][transaction_id])
@@ -806,24 +850,36 @@ class TestCompany(TestCase):
             "target": [
                 {
                     "transaction_id": merger.transaction_id,
+                    "status": merger.status,
                     "merger_title": merger.merger_title,
+                    "start_date": merger.start_date,
                     "closed_date": merger.closed_date,
+                    "target": merger.target,
+                    "buyers": merger.buyers,
                 }
                 for merger in mergers["target"]
             ],
             "buyer": [
                 {
                     "transaction_id": merger.transaction_id,
+                    "status": merger.status,
                     "merger_title": merger.merger_title,
+                    "start_date": merger.start_date,
                     "closed_date": merger.closed_date,
+                    "target": merger.target,
+                    "buyers": merger.buyers,
                 }
                 for merger in mergers["buyer"]
             ],
             "seller": [
                 {
                     "transaction_id": merger.transaction_id,
+                    "status": merger.status,
                     "merger_title": merger.merger_title,
+                    "start_date": merger.start_date,
                     "closed_date": merger.closed_date,
+                    "target": merger.target,
+                    "buyers": merger.buyers,
                 }
                 for merger in mergers["seller"]
             ],

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_models.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_models.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date as date_type
 from decimal import Decimal
 
 from pydantic import BaseModel
@@ -9,7 +9,11 @@ from kfinance.domains.companies.company_models import CompanyId, CompanyIdAndNam
 class MergerSummary(BaseModel):
     transaction_id: int
     merger_title: str
-    closed_date: date | None
+    status: str
+    start_date: date_type | None
+    closed_date: date_type | None
+    target: str
+    buyers: list[str]
 
 
 class MergersResp(BaseModel):
@@ -26,13 +30,17 @@ class AdvisorResp(BaseModel):
 
 class MergerTimelineElement(BaseModel):
     status: str
-    date: date
+    date: date_type
+
+
+class MergerParticipant(CompanyIdAndName):
+    advisors: list[AdvisorResp] | None
 
 
 class MergerParticipants(BaseModel):
-    target: CompanyIdAndName
-    buyers: list[CompanyIdAndName]
-    sellers: list[CompanyIdAndName]
+    target: MergerParticipant
+    buyers: list[MergerParticipant]
+    sellers: list[MergerParticipant]
 
 
 class MergerConsiderationDetail(BaseModel):
@@ -55,3 +63,11 @@ class MergerInfo(BaseModel):
     timeline: list[MergerTimelineElement]
     participants: MergerParticipants
     consideration: MergerConsideration | None = None
+
+
+class NoMergerFound(BaseModel):
+    error: str
+
+
+class MergersInfo(BaseModel):
+    results: dict[int, MergerInfo | NoMergerFound]

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_models.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_models.py
@@ -8,7 +8,6 @@ from kfinance.domains.companies.company_models import CompanyId, CompanyIdAndNam
 
 class MergerSummary(BaseModel):
     transaction_id: int
-    merger_title: str
     status: str
     start_date: date_type | None
     closed_date: date_type | None

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
@@ -52,7 +52,7 @@ class GetMergersFromIdentifiers(KfinanceTool):
 
         Results are categorized by the company's role: target (being acquired), buyer (making the acquisition), or seller (divesting an asset).
 
-        This tool returns ONLY transaction_id, status, start_date, closed_date, target, and buyers for each transaction. It does NOT return deal/transaction values or amounts paid, completion status, or participant details. To get any of those, take all relevant transaction_ids from this responses and call get_mergers_info_from_transaction_ids with them.
+        This tool returns ONLY transaction_id, status, start_date, closed_date, target, and buyers for each transaction. It does NOT return deal/transaction values, amounts paid, or participant details. To get any of those, take all relevant transaction_ids from this responses and call get_mergers_info_from_transaction_ids with them.
 
         - The numeric identifier of a COMPANY is never a transaction_id. Always obtain transaction_id values from this tool's response — never pass a company identifier to get_mergers_info_from_transaction_ids.
         - When possible, pass multiple identifiers in a single call rather than making multiple calls.

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
@@ -10,7 +10,7 @@ from kfinance.client.id_resolution import unified_fetch_id_triples
 from kfinance.client.permission_models import Permission
 from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_models import (
     AdvisorResp,
-    MergerInfo,
+    MergersInfo,
     MergersResp,
 )
 from kfinance.integrations.tool_calling.tool_calling_models import (
@@ -52,9 +52,9 @@ class GetMergersFromIdentifiers(KfinanceTool):
 
         Results are categorized by the company's role: target (being acquired), buyer (making the acquisition), or seller (divesting an asset).
 
-        This tool returns ONLY transaction_id, merger_title, and closed_date for each transaction. It does NOT return announcement dates, deal/transaction values or amounts paid, completion status, or participant details. To get any of those, take each relevant transaction_id from this response and call get_merger_info_from_transaction_id (call it once per relevant transaction_id).
+        This tool returns ONLY transaction_id, merger_title, status, start_date, closed_date, target, and buyers for each transaction. It does NOT return deal/transaction values or amounts paid, completion status, or participant details. To get any of those, take all relevant transaction_ids from this responses and call get_mergers_info_from_transaction_ids with them.
 
-        - The numeric identifier of a COMPANY is never a transaction_id. Always obtain transaction_id values from this tool's response — never pass a company identifier to get_merger_info_from_transaction_id.
+        - The numeric identifier of a COMPANY is never a transaction_id. Always obtain transaction_id values from this tool's response — never pass a company identifier to get_mergers_info_from_transaction_ids.
         - When possible, pass multiple identifiers in a single call rather than making multiple calls.
         - When requesting all mergers, leave start_date and end_date null.
         - Only specify date ranges when the user explicitly requests mergers and acquisitions during some date range.
@@ -85,46 +85,50 @@ class GetMergersFromIdentifiers(KfinanceTool):
         )
 
 
-class GetMergerInfoFromTransactionIdArgs(BaseModel):
-    transaction_id: int = Field(description="The ID of the transaction.")
+class GetMergersInfoFromTransactionIdsArgs(BaseModel):
+    transaction_ids: list[int] = Field(description="The IDs of the transactions.")
+    include_advisors: bool = Field(
+        default=False, description="Whether to include advisors for participants in the response"
+    )
 
 
-class GetMergerInfoFromTransactionId(KfinanceTool):
-    name: str = "get_merger_info_from_transaction_id"
+class GetMergersInfoFromTransactionIds(KfinanceTool):
+    name: str = "get_mergers_info_from_transaction_ids"
     description: str = dedent("""
-        Provides comprehensive information about a specific merger or acquisition transaction, including its timeline (announced date, closed date), participants' company_name and company_id (target, buyers, sellers), and financial consideration details (including monetary values).
+        Provides comprehensive information about merger or acquisition transactions, including their timeline (announced date, closed date), participants' company_names, company_ids, and advisors (if advisors are requested) (target, buyers, sellers), and financial consideration details (including monetary values).
 
         Use this tool for questions about announcement dates, deal/transaction values or amounts paid, completion status, and transaction details.
 
-        The transaction_id argument MUST come from a get_mergers_from_identifiers response. It is NOT a company_id or ticker. If you have not yet called get_mergers_from_identifiers for the company in question, do that first.
+        The transaction_ids MUST come from get_mergers_from_identifiers responses. They are NOT company_ids or tickers. If you have not yet called get_mergers_from_identifiers for the company in question, do that first.
 
-        When a question concerns more than one transaction (e.g. "all acquisitions over $5B", "deals since 2020"), call this tool once for EVERY transaction_id from the get_mergers_from_identifiers response that matches the criteria — not just the first one.
+        When a question concerns more than one transaction (e.g. "all acquisitions over $5B", "deals since 2020"), call this tool and pass in EVERY transaction_id from the get_mergers_from_identifiers response that matches the criteria — not just the first one.
 
         Examples:
         Query: "When was the acquisition of Ben & Jerry's announced?"
         Function 1: get_mergers_from_identifiers(identifiers=["Ben & Jerry's"])
         # Function 1 returns all M&A's that involved Ben & Jerry's. Extract the <transaction_id> from the response where Ben & Jerry's was the target.
-        Function 2: get_merger_info_from_transaction_id(transaction_id=<transaction_id>)
+        Function 2: get_mergesr_info_from_transaction_ids(transaction_ids=[<transaction_id>])
 
         Query: "What was the transaction size of Vodafone's acquisition of Mannesmann?"
         Function 1: get_mergers_from_identifiers(identifiers=["Vodafone"])
         # Function 1 returns all M&A's that involved Vodafone. Extract the <transaction_id> from the response where Vodafone was the buyer and Mannesmann was the target.
-        Function 2: get_merger_info_from_transaction_id(transaction_id=<transaction_id>)
+        Function 2: get_mergesr_info_from_transaction_ids(transaction_ids=[<transaction_id>])
 
-        Query: "List Microsoft's acquisitions over $5 billion announced since 2020."
+        Query: "List Microsoft's acquisitions over $5 billion announced since 2020, along with the advisors for the acquisitions."
         Function 1: get_mergers_from_identifiers(identifiers=["Microsoft"], start_date="2020-01-01")
-        # Function 1 returns transactions where Microsoft was the buyer, each with a transaction_id. Deal value and announcement date are NOT in that response, so call get_merger_info for EACH candidate transaction_id to check the $5B threshold and the announcement date.
-        Function 2: get_merger_info_from_transaction_id(transaction_id=<transaction_id_1>)
-        Function 3: get_merger_info_from_transaction_id(transaction_id=<transaction_id_2>)
-        Function 4: get_merger_info_from_transaction_id(transaction_id=<transaction_id_3>)
+        # Function 1 returns transactions where Microsoft was the buyer, each with a transaction_id. Deal value and announcement date are NOT in that response, so call get_mergers_info_from_transaction_ids, passing in EVERY candidate transaction_id to check the $5B threshold, the announcement date, and advisors.
+        Function 2: get_mergers_info_from_transaction_ids(transaction_ids=[<transaction_id_1>, <transaction_id_2>, <transaction_id_3>], include_advisors=True)
     """).strip()
-    args_schema: Type[BaseModel] = GetMergerInfoFromTransactionIdArgs
+    args_schema: Type[BaseModel] = GetMergersInfoFromTransactionIdsArgs
     accepted_permissions: set[Permission] | None = {Permission.MergersPermission}
 
-    async def _arun(self, transaction_id: int) -> MergerInfo:
+    async def _arun(
+        self, transaction_ids: list[int], include_advisors: bool = False
+    ) -> MergersInfo:
         """"""
-        return await get_merger_info_from_transaction_id(
-            transaction_id=transaction_id,
+        return await get_mergers_info_from_transaction_ids(
+            transaction_ids=transaction_ids,
+            include_advisors=include_advisors,
             httpx_client=self.kfinance_client.httpx_client,
         )
 
@@ -224,15 +228,18 @@ async def fetch_mergers_from_company_id(
     return MergersResp.model_validate(resp.json())
 
 
-async def get_merger_info_from_transaction_id(
-    transaction_id: int,
+async def get_mergers_info_from_transaction_ids(
+    transaction_ids: list[int],
+    include_advisors: bool,
     httpx_client: httpx.AsyncClient,
-) -> MergerInfo:
+) -> MergersInfo:
     """Fetch detailed merger info for a transaction ID."""
-    url = f"/merger/info/{transaction_id}"
-    resp = await httpx_client.get(url=url)
+    resp = await httpx_client.post(
+        url="/mergers/info",
+        json={"transaction_ids": transaction_ids, "include_advisors": include_advisors},
+    )
     resp.raise_for_status()
-    return MergerInfo.model_validate(resp.json())
+    return MergersInfo.model_validate(resp.json())
 
 
 async def get_advisors_for_company_in_transaction_from_identifier(

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
@@ -95,7 +95,7 @@ class GetMergersInfoFromTransactionIdsArgs(BaseModel):
 class GetMergersInfoFromTransactionIds(KfinanceTool):
     name: str = "get_mergers_info_from_transaction_ids"
     description: str = dedent("""
-        Provides comprehensive information about merger or acquisition transactions, including their timeline (announced date, closed date), participants' company_names, company_ids, and advisors (if advisors are requested) (target, buyers, sellers), and financial consideration details (including monetary values).
+        Provides comprehensive information about merger or acquisition transactions, including their timeline (announced date, closed date), participants' company_names, company_ids, and advisors if advisors are requested (participants are categorized as target, buyers, sellers), and financial consideration details (including monetary values).
 
         Use this tool for questions about announcement dates, deal/transaction values or amounts paid, completion status, and transaction details.
 
@@ -107,12 +107,12 @@ class GetMergersInfoFromTransactionIds(KfinanceTool):
         Query: "When was the acquisition of Ben & Jerry's announced?"
         Function 1: get_mergers_from_identifiers(identifiers=["Ben & Jerry's"])
         # Function 1 returns all M&A's that involved Ben & Jerry's. Extract the <transaction_id> from the response where Ben & Jerry's was the target.
-        Function 2: get_mergesr_info_from_transaction_ids(transaction_ids=[<transaction_id>])
+        Function 2: get_mergers_info_from_transaction_ids(transaction_ids=[<transaction_id>])
 
         Query: "What was the transaction size of Vodafone's acquisition of Mannesmann?"
         Function 1: get_mergers_from_identifiers(identifiers=["Vodafone"])
         # Function 1 returns all M&A's that involved Vodafone. Extract the <transaction_id> from the response where Vodafone was the buyer and Mannesmann was the target.
-        Function 2: get_mergesr_info_from_transaction_ids(transaction_ids=[<transaction_id>])
+        Function 2: get_mergers_info_from_transaction_ids(transaction_ids=[<transaction_id>])
 
         Query: "List Microsoft's acquisitions over $5 billion announced since 2020, along with the advisors for the acquisitions."
         Function 1: get_mergers_from_identifiers(identifiers=["Microsoft"], start_date="2020-01-01")

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
@@ -52,13 +52,13 @@ class GetMergersFromIdentifiers(KfinanceTool):
 
         Results are categorized by the company's role: target (being acquired), buyer (making the acquisition), or seller (divesting an asset).
 
-        This tool returns ONLY transaction_id, merger_title, status, start_date, closed_date, target, and buyers for each transaction. It does NOT return deal/transaction values or amounts paid, completion status, or participant details. To get any of those, take all relevant transaction_ids from this responses and call get_mergers_info_from_transaction_ids with them.
+        This tool returns ONLY transaction_id, status, start_date, closed_date, target, and buyers for each transaction. It does NOT return deal/transaction values or amounts paid, completion status, or participant details. To get any of those, take all relevant transaction_ids from this responses and call get_mergers_info_from_transaction_ids with them.
 
         - The numeric identifier of a COMPANY is never a transaction_id. Always obtain transaction_id values from this tool's response — never pass a company identifier to get_mergers_info_from_transaction_ids.
         - When possible, pass multiple identifiers in a single call rather than making multiple calls.
         - When requesting all mergers, leave start_date and end_date null.
         - Only specify date ranges when the user explicitly requests mergers and acquisitions during some date range.
-        - Provides transaction_id, merger_title, and transaction closed_date.
+        - Provides transaction_id, status, start_date, closed_date, target, and buyers.
 
         Examples:
         Query: "Which companies did Microsoft purchase?"

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
@@ -201,5 +201,3 @@ async def get_mergers_info_from_transaction_ids(
     )
     resp.raise_for_status()
     return MergersInfo.model_validate(resp.json())
-
-

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
@@ -9,15 +9,12 @@ from kfinance.async_batch_execution import AsyncTask, batch_execute_async_tasks
 from kfinance.client.id_resolution import unified_fetch_id_triples
 from kfinance.client.permission_models import Permission
 from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_models import (
-    AdvisorResp,
     MergersInfo,
     MergersResp,
 )
 from kfinance.integrations.tool_calling.tool_calling_models import (
     KfinanceTool,
-    ToolArgsWithIdentifier,
     ToolArgsWithIdentifiers,
-    ToolRespWithErrors,
     ToolRespWithIdInfoAndErrors,
 )
 
@@ -133,42 +130,6 @@ class GetMergersInfoFromTransactionIds(KfinanceTool):
         )
 
 
-class GetAdvisorsForCompanyInTransactionFromIdentifierArgs(ToolArgsWithIdentifier):
-    transaction_id: int = Field(description="The ID of the merger.")
-
-
-class GetAdvisorsForCompanyInTransactionFromIdentifierResp(ToolRespWithErrors):
-    results: list[AdvisorResp]
-
-
-class GetAdvisorsForCompanyInTransactionFromIdentifier(KfinanceTool):
-    name: str = "get_advisors_for_company_in_transaction"
-    description: str = dedent("""
-        Returns a list of advisor companies that provided advisory services to the specified company during a particular merger or acquisition transaction.
-
-        Examples:
-        Query: "Who advised S&P Global during their purchase of Kensho?"
-        Function 1: get_mergers_from_identifiers(identifiers=["S&P Global"])
-        # Function 1 returns all M&A's that involved S&P Global. Extract the <transaction_id> from the response where S&P Global was the buyer and Kensho was the target.
-        Function 2: get_advisors_for_company_in_transaction(identifier="S&P Global", transaction_id=<transaction_id>)
-
-        Query: "Which firms advised AAPL in transaction 67890?"
-        Function: get_advisors_for_company_in_transaction(identifier="AAPL", transaction_id=67890)
-    """).strip()
-    args_schema: Type[BaseModel] = GetAdvisorsForCompanyInTransactionFromIdentifierArgs
-    accepted_permissions: set[Permission] | None = {Permission.MergersPermission}
-
-    async def _arun(
-        self, identifier: str, transaction_id: int
-    ) -> GetAdvisorsForCompanyInTransactionFromIdentifierResp:
-        """"""
-        return await get_advisors_for_company_in_transaction_from_identifier(
-            identifier=identifier,
-            transaction_id=transaction_id,
-            httpx_client=self.kfinance_client.httpx_client,
-        )
-
-
 async def get_mergers_from_identifiers(
     identifiers: list[str],
     httpx_client: httpx.AsyncClient,
@@ -242,44 +203,3 @@ async def get_mergers_info_from_transaction_ids(
     return MergersInfo.model_validate(resp.json())
 
 
-async def get_advisors_for_company_in_transaction_from_identifier(
-    identifier: str,
-    transaction_id: int,
-    httpx_client: httpx.AsyncClient,
-) -> GetAdvisorsForCompanyInTransactionFromIdentifierResp:
-    """Fetch advisors for a company in a specific transaction."""
-
-    # First resolve the identifier to company ID
-    id_triple_resp = await unified_fetch_id_triples(
-        identifiers=[identifier], httpx_client=httpx_client
-    )
-
-    # If the identifier cannot be resolved, return the associated error
-    if id_triple_resp.errors:
-        return GetAdvisorsForCompanyInTransactionFromIdentifierResp(
-            results=[], errors=list(id_triple_resp.errors.values())
-        )
-
-    id_triple = id_triple_resp.identifiers_to_id_triples[identifier]
-    company_id = id_triple.company_id
-
-    # Fetch advisors for this company in the transaction
-    url = f"/merger/info/{transaction_id}/advisors/{company_id}"
-    resp = await httpx_client.get(url=url)
-    resp.raise_for_status()
-    response_data = resp.json()
-
-    advisors_response: list[AdvisorResp] = []
-    if "advisors" in response_data and response_data["advisors"]:
-        for advisor in response_data["advisors"]:
-            advisors_response.append(
-                AdvisorResp(
-                    advisor_company_id=advisor["advisor_company_id"],
-                    advisor_company_name=advisor["advisor_company_name"],
-                    advisor_type_name=advisor["advisor_type_name"],
-                )
-            )
-
-    return GetAdvisorsForCompanyInTransactionFromIdentifierResp(
-        results=advisors_response, errors=[]
-    )

--- a/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
@@ -195,4 +195,3 @@ class TestMergersAndAcquisitions:
         )
 
         assert ordered(resp) == ordered(expected_response)
-

--- a/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from datetime import date
 
 import httpx
@@ -11,15 +10,12 @@ from kfinance.client.tests.test_objects import (
 )
 from kfinance.conftest import SPGI_ID_TRIPLE
 from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_models import (
-    AdvisorResp,
     MergersInfo,
     MergersResp,
 )
 from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_tools import (
-    GetAdvisorsForCompanyInTransactionFromIdentifierResp,
     GetMergersFromIdentifiersResp,
     fetch_mergers_from_company_id,
-    get_advisors_for_company_in_transaction_from_identifier,
     get_mergers_from_identifiers,
     get_mergers_info_from_transaction_ids,
 )
@@ -200,71 +196,3 @@ class TestMergersAndAcquisitions:
 
         assert ordered(resp) == ordered(expected_response)
 
-    @pytest.mark.asyncio
-    async def test_get_advisors_for_company_in_transaction_from_identifier(
-        self,
-        httpx_client: httpx.AsyncClient,
-        httpx_mock: HTTPXMock,
-    ) -> None:
-        """
-        WHEN we request advisors for a company in a specific transaction
-        THEN we get back the advisor information
-        """
-        transaction_id = 554979212
-
-        advisor_data = {
-            "advisor_company_id": 251994106,
-            "advisor_company_name": "Kensho Technologies, Inc.",
-            "advisor_type_name": "Professional Mongo Enjoyer",
-        }
-
-        httpx_mock.add_response(
-            method="GET",
-            url=f"https://kfinance.kensho.com/api/v1/merger/info/{transaction_id}/advisors/{SPGI_ID_TRIPLE.company_id}",
-            json={"advisors": [deepcopy(advisor_data)]},
-        )
-
-        expected_response = GetAdvisorsForCompanyInTransactionFromIdentifierResp(
-            results=[
-                AdvisorResp(
-                    advisor_company_id=251994106,
-                    advisor_company_name="Kensho Technologies, Inc.",
-                    advisor_type_name="Professional Mongo Enjoyer",
-                )
-            ],
-            errors=[],
-        )
-
-        resp = await get_advisors_for_company_in_transaction_from_identifier(
-            identifier="SPGI",
-            transaction_id=transaction_id,
-            httpx_client=httpx_client,
-        )
-
-        assert resp == expected_response
-
-    @pytest.mark.asyncio
-    async def test_get_advisors_for_company_in_transaction_from_bad_identifier(
-        self,
-        httpx_client: httpx.AsyncClient,
-    ) -> None:
-        """
-        WHEN we request advisors for a non-existent company identifier
-        THEN we get back an error
-        """
-        transaction_id = 554979212
-
-        expected_response = GetAdvisorsForCompanyInTransactionFromIdentifierResp(
-            results=[],
-            errors=[
-                "No identification triple found for the provided identifier: NON-EXISTENT of type: ticker"
-            ],
-        )
-
-        resp = await get_advisors_for_company_in_transaction_from_identifier(
-            identifier="non-existent",
-            transaction_id=transaction_id,
-            httpx_client=httpx_client,
-        )
-
-        assert resp == expected_response

--- a/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
@@ -12,7 +12,7 @@ from kfinance.client.tests.test_objects import (
 from kfinance.conftest import SPGI_ID_TRIPLE
 from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_models import (
     AdvisorResp,
-    MergerInfo,
+    MergersInfo,
     MergersResp,
 )
 from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_tools import (
@@ -20,8 +20,8 @@ from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_tools impo
     GetMergersFromIdentifiersResp,
     fetch_mergers_from_company_id,
     get_advisors_for_company_in_transaction_from_identifier,
-    get_merger_info_from_transaction_id,
     get_mergers_from_identifiers,
+    get_mergers_info_from_transaction_ids,
 )
 
 
@@ -116,7 +116,7 @@ class TestMergersAndAcquisitions:
         assert resp == expected_resp
 
     @pytest.mark.asyncio
-    async def test_get_merger_info_from_transaction_id(
+    async def test_get_mergers_info_from_transaction_ids(
         self,
         httpx_client: httpx.AsyncClient,
         httpx_mock: HTTPXMock,
@@ -126,17 +126,20 @@ class TestMergersAndAcquisitions:
         THEN we get back the detailed merger information
         """
         transaction_id = 517414
+        error_transaction_id = 0
 
         timeline_resp = [
             {"status": "Announced", "date": "2000-09-12"},
             {"status": "Closed", "date": "2000-09-12"},
         ]
         participants_resp = {
-            "target": {"company_id": 31696, "company_name": "MongoMusic, Inc."},
-            "buyers": [{"company_id": 21835, "company_name": "Microsoft Corporation"}],
+            "target": {"company_id": 31696, "company_name": "MongoMusic, Inc.", "advisors": None},
+            "buyers": [
+                {"company_id": 21835, "company_name": "Microsoft Corporation", "advisors": None}
+            ],
             "sellers": [
-                {"company_id": 18805, "company_name": "Angel Investors L.P."},
-                {"company_id": 20087, "company_name": "Draper Richards, L.P."},
+                {"company_id": 18805, "company_name": "Angel Investors L.P.", "advisors": None},
+                {"company_id": 20087, "company_name": "Draper Richards, L.P.", "advisors": None},
             ],
         }
         consideration_resp = {
@@ -155,26 +158,43 @@ class TestMergersAndAcquisitions:
             ],
         }
 
+        error_resp = f"No merger found for transaction_id: {error_transaction_id}"
+
         httpx_mock.add_response(
-            method="GET",
-            url=f"https://kfinance.kensho.com/api/v1/merger/info/{transaction_id}",
+            method="POST",
+            url=f"https://kfinance.kensho.com/api/v1/mergers/info",
+            match_json={
+                "transaction_ids": [transaction_id, error_transaction_id],
+                "include_advisors": True,
+            },
             json={
-                "timeline": timeline_resp,
-                "participants": participants_resp,
-                "consideration": consideration_resp,
+                "results": {
+                    transaction_id: {
+                        "timeline": timeline_resp,
+                        "participants": participants_resp,
+                        "consideration": consideration_resp,
+                    },
+                    error_transaction_id: {"error": error_resp},
+                }
             },
         )
 
-        expected_response = MergerInfo.model_validate(
+        expected_response = MergersInfo.model_validate(
             {
-                "timeline": timeline_resp,
-                "participants": participants_resp,
-                "consideration": consideration_resp,
+                "results": {
+                    transaction_id: {
+                        "timeline": timeline_resp,
+                        "participants": participants_resp,
+                        "consideration": consideration_resp,
+                    },
+                    error_transaction_id: {"error": error_resp},
+                }
             }
         )
 
-        resp = await get_merger_info_from_transaction_id(
-            transaction_id=transaction_id,
+        resp = await get_mergers_info_from_transaction_ids(
+            transaction_ids=[transaction_id, error_transaction_id],
+            include_advisors=True,
             httpx_client=httpx_client,
         )
 

--- a/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
@@ -122,8 +122,8 @@ class TestMergersAndAcquisitions:
         httpx_mock: HTTPXMock,
     ) -> None:
         """
-        WHEN we request merger info for a specific transaction
-        THEN we get back the detailed merger information
+        WHEN we request merger info for multiple transactions
+        THEN we get back the detailed merger information for each of them
         """
         transaction_id = 517414
         error_transaction_id = 0

--- a/kfinance/integrations/tool_calling/all_tools.py
+++ b/kfinance/integrations/tool_calling/all_tools.py
@@ -35,7 +35,6 @@ from kfinance.domains.line_items.line_item_tools_va import (
     GetVisibleAlphaFinancialLineItemFromIdentifiers,
 )
 from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_tools import (
-    GetAdvisorsForCompanyInTransactionFromIdentifier,
     GetMergersFromIdentifiers,
     GetMergersInfoFromTransactionIds,
 )
@@ -103,7 +102,6 @@ ALL_TOOLS: list[type[KfinanceTool]] = [
     # Statements
     GetFinancialStatementFromIdentifiers,
     # Mergers & Acquisitions
-    GetAdvisorsForCompanyInTransactionFromIdentifier,
     GetMergersInfoFromTransactionIds,
     GetMergersFromIdentifiers,
     # Rounds of Funding

--- a/kfinance/integrations/tool_calling/all_tools.py
+++ b/kfinance/integrations/tool_calling/all_tools.py
@@ -30,8 +30,8 @@ from kfinance.domains.key_developments.key_devs_tools import GetKeyDevsFromIdent
 from kfinance.domains.line_items.line_item_tools import GetFinancialLineItemFromIdentifiers
 from kfinance.domains.mergers_and_acquisitions.merger_and_acquisition_tools import (
     GetAdvisorsForCompanyInTransactionFromIdentifier,
-    GetMergerInfoFromTransactionId,
     GetMergersFromIdentifiers,
+    GetMergersInfoFromTransactionIds,
 )
 from kfinance.domains.prices.price_tools import (
     GetHistoryMetadataFromIdentifiers,
@@ -95,7 +95,7 @@ ALL_TOOLS: list[type[KfinanceTool]] = [
     GetFinancialStatementFromIdentifiers,
     # Mergers & Acquisitions
     GetAdvisorsForCompanyInTransactionFromIdentifier,
-    GetMergerInfoFromTransactionId,
+    GetMergersInfoFromTransactionIds,
     GetMergersFromIdentifiers,
     # Rounds of Funding
     GetRoundsOfFundingFromIdentifiers,


### PR DESCRIPTION
The API was recently updated to return additional information, including the status, start date, target, and buyers, with each merger list call. This information is now included in the `get_mergers_from_identifiers` tool call response. Note that some of the information is redundant with what was included in the merger title, so that field has been removed. 

Additionally, the merger info tool call is replaced with a batch version, now called `get_mergers_info_from_transaction_ids`. This new tool call also supports the option of including advisors for participants in the response.