### PR TITLE
Gracefully handle stringified `identifiers` params

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v6.6.1
+- Gracefully handle stringified `identifiers` params
+
 ## v6.6.0
 - Add GetVisibleAlphaConsensusEstimatesFromIdentifiers
 - Add GetVisibleAlphaFinancialLineItemFromIdentifiers

--- a/kfinance/integrations/tool_calling/tests/test_tool_calling_models.py
+++ b/kfinance/integrations/tool_calling/tests/test_tool_calling_models.py
@@ -27,9 +27,36 @@ from kfinance.domains.companies.company_tools import (
 )
 from kfinance.integrations.tool_calling.tool_calling_models import (
     IdentifierInfoWithResult,
+    ToolArgsWithIdentifiers,
     ToolRespWithIdInfoAndErrors,
     ValidQuarter,
 )
+
+
+class TestIdentifiersCoercion:
+    """LLMs sometimes pass identifiers as a bare string or a stringified JSON list."""
+
+    @pytest.mark.parametrize(
+        "input_val, expected",
+        [
+            pytest.param(["IBM", "AAPL"], ["IBM", "AAPL"], id="normal list unchanged"),
+            pytest.param("IBM", ["IBM"], id="bare string wrapped in list"),
+            pytest.param('["IBM", "AAPL"]', ["IBM", "AAPL"], id="stringified list parsed"),
+            pytest.param('["IBM"]', ["IBM"], id="stringified single-element list"),
+            pytest.param(" IBM ", ["IBM"], id="bare string stripped"),
+            pytest.param("[not json", ["[not json"], id="malformed bracket string treated as bare"),
+        ],
+    )
+    def test_coerce_identifiers(self, input_val: Any, expected: list[str]) -> None:
+        result = ToolArgsWithIdentifiers.model_validate({"identifiers": input_val})
+        assert result.identifiers == expected
+
+    def test_empty_string_raises(self) -> None:
+        """min_length=1 still enforced after coercion wraps bare string."""
+        # A bare empty string becomes [""] which has length 1 — that's fine.
+        # But an empty list should still fail.
+        with pytest.raises(ValidationError):
+            ToolArgsWithIdentifiers.model_validate({"identifiers": "[]"})
 
 
 class TestGetEndpointsFromToolCallsWithGrounding:

--- a/kfinance/integrations/tool_calling/tool_calling_models.py
+++ b/kfinance/integrations/tool_calling/tool_calling_models.py
@@ -1,4 +1,5 @@
 import abc
+import json
 from typing import Annotated, Any, Callable, Coroutine, Dict, Generic, Literal, Type, TypeVar
 
 from asyncer import syncify
@@ -11,6 +12,7 @@ from pydantic import (
     ConfigDict,
     Field,
     computed_field,
+    field_validator,
     model_serializer,
 )
 
@@ -151,6 +153,27 @@ class ToolArgsWithIdentifiers(BaseModel):
         min_length=1,
         description="The identifiers, which can be a list of ticker symbols, ISINs, CUSIPs, company names, or company_ids",
     )
+
+    @field_validator("identifiers", mode="before")
+    @classmethod
+    def coerce_identifiers(cls, v: Any) -> list[str]:
+        """Handle bare string ("IBM") and stringified JSON list ('["IBM", "AAPL"]')
+
+        LLMs sometimes pass them instead of the expected list[str]. Coerce both into the correct form.
+        """
+        if isinstance(v, str):
+            v = v.strip()
+            # Handle stringified JSON lists like '["IBM", "AAPL"]'
+            if v.startswith("[") and v.endswith("]"):
+                try:
+                    parsed = json.loads(v)
+                    if isinstance(parsed, list):
+                        return [str(item) for item in parsed]
+                except (json.JSONDecodeError, ValueError):
+                    pass
+            # Bare string like "IBM" -> ["IBM"]
+            return [v]
+        return v
 
 
 def convert_str_to_int(v: Any) -> Any:


### PR DESCRIPTION
Handle bare string ("IBM") and stringified JSON list ('["IBM", "AAPL"]')
LLMs sometimes pass them instead of the expected list[str]. Coerce both into the correct form.