### PR TITLE
Add additional data items to mergers info tool call response

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 7.1.0
--- Add additional data items to mergers info tool call response
+- Add additional data items to `get_mergers_info_from_transaction_ids` tool call response.
+- Add `include_comments` parameter to `get_mergers_info_from_transaction_ids` tool call.
 
 ## v7.0.2
 - Modify GetIssuerRatingsFromIdentifiers tool description.

--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.1.0
+-- Add additional data items to mergers info tool call response
+
 ## v7.0.2
 - Modify GetIssuerRatingsFromIdentifiers tool description.
 

--- a/kfinance/client/fetch.py
+++ b/kfinance/client/fetch.py
@@ -863,7 +863,10 @@ class KFinanceApiClient:
         return MergersResp.model_validate(self.fetch(url))
 
     def fetch_mergers_info(
-        self, transaction_ids: list[int], include_advisors: bool = False
+        self,
+        transaction_ids: list[int],
+        include_advisors: bool = False,
+        include_comments: bool = False,
     ) -> MergersInfo:
         """Fetches information about the given mergers or acquisitions, including the timeline, the participants, and the considerations.
 
@@ -875,7 +878,11 @@ class KFinanceApiClient:
         :rtype: MergerInfo
         """
         url = f"{self.url_base}mergers/info"
-        request_body = {"transaction_ids": transaction_ids, "include_advisors": include_advisors}
+        request_body = {
+            "transaction_ids": transaction_ids,
+            "include_advisors": include_advisors,
+            "include_comments": include_comments,
+        }
 
         return MergersInfo.model_validate(self.fetch(url, method="POST", request_body=request_body))
 

--- a/kfinance/client/tests/test_fetch.py
+++ b/kfinance/client/tests/test_fetch.py
@@ -407,11 +407,15 @@ class TestFetchItem(TestCase):
     def test_fetch_mergers_info(self) -> None:
         transaction_id = 554979212
         expected_fetch_url = f"{self.kfinance_api_client.url_base}mergers/info"
-        expected_request_body = {"transaction_ids": [transaction_id], "include_advisors": True}
+        expected_request_body = {
+            "transaction_ids": [transaction_id],
+            "include_advisors": True,
+            "include_comments": True,
+        }
         # Validation error is ok, we only care that the function was called with the correct url
         with pytest.raises(ValidationError):
             self.kfinance_api_client.fetch_mergers_info(
-                transaction_ids=[transaction_id], include_advisors=True
+                transaction_ids=[transaction_id], include_advisors=True, include_comments=True
             )
         self.kfinance_api_client.fetch.assert_called_with(
             expected_fetch_url, method="POST", request_body=expected_request_body

--- a/kfinance/client/tests/test_objects.py
+++ b/kfinance/client/tests/test_objects.py
@@ -421,28 +421,52 @@ MOCK_MERGERS_DB = {
                 "target": {
                     "company_id": 31696,
                     "company_name": "MongoMusic, Inc.",
+                    "percent_ownership": None,
                     "advisors": None,
                 },
                 "buyers": [
-                    {"company_id": 21835, "company_name": "Microsoft Corporation", "advisors": None}
+                    {
+                        "company_id": 21835,
+                        "company_name": "Microsoft Corporation",
+                        "percent_ownership": "100.00",
+                        "advisors": None,
+                    }
                 ],
                 "sellers": [
-                    {"company_id": 18805, "company_name": "Angel Investors L.P.", "advisors": None},
+                    {
+                        "company_id": 18805,
+                        "company_name": "Angel Investors L.P.",
+                        "percent_ownership": None,
+                        "advisors": None,
+                    },
                     {
                         "company_id": 20087,
                         "company_name": "Draper Richards, L.P.",
+                        "percent_ownership": None,
                         "advisors": None,
                     },
-                    {"company_id": 22103, "company_name": "BRV Partners, LLC", "advisors": None},
-                    {"company_id": 23745, "company_name": "Venture Frogs, LLC", "advisors": None},
+                    {
+                        "company_id": 22103,
+                        "company_name": "BRV Partners, LLC",
+                        "percent_ownership": None,
+                        "advisors": None,
+                    },
+                    {
+                        "company_id": 23745,
+                        "company_name": "Venture Frogs, LLC",
+                        "percent_ownership": None,
+                        "advisors": None,
+                    },
                     {
                         "company_id": 105902,
                         "company_name": "ARGUS Capital International Limited",
+                        "percent_ownership": None,
                         "advisors": None,
                     },
                     {
                         "company_id": 880300,
                         "company_name": "Sony Music Entertainment, Inc.",
+                        "percent_ownership": None,
                         "advisors": None,
                     },
                 ],
@@ -452,6 +476,20 @@ MOCK_MERGERS_DB = {
                 "current_calculated_gross_total_transaction_value": "51609375.000000",
                 "current_calculated_implied_equity_value": "51609375.000000",
                 "current_calculated_implied_enterprise_value": "51609375.000000",
+                "presentation_gross_total_transaction_value": "51609375.000000",
+                "presentation_implied_equity_value": "51609375.000000",
+                "presentation_implied_enterprise_value": "51609375.000000",
+                "target_stock_premium_1_day_prior": None,
+                "target_stock_premium_7_days_prior": None,
+                "target_stock_premium_30_days_prior": None,
+                "current_calculated_tev_ebit": None,
+                "current_calculated_tev_ebitda": None,
+                "current_calculated_tev_revenues": None,
+                "current_calculated_equity_net_income": None,
+                "presentation_tev_ebit": None,
+                "presentation_tev_ebitda": None,
+                "presentation_tev_revenues": None,
+                "presentation_equity_net_income": None,
                 "details": [
                     {
                         "scenario": "Stock Lump Sum",
@@ -461,6 +499,11 @@ MOCK_MERGERS_DB = {
                         "current_calculated_gross_value_of_consideration": "51609375.000000",
                     }
                 ],
+            },
+            "details": {
+                "buy_side_termination_fee": None,
+                "sell_side_termination_fee": None,
+                "comment": "Microsoft Corp. (Nasdaq: MSFT) acquired MongoMusic Inc. for approximately $51.6 million in stock on October 12, 2000.",
             },
         }
     )

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_models.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_models.py
@@ -25,6 +25,8 @@ class AdvisorResp(BaseModel):
     advisor_company_id: CompanyId
     advisor_company_name: str
     advisor_type_name: str | None
+    advisor_fee_amount: Decimal | None
+    advisor_fee_currency: str | None
 
 
 class MergerTimelineElement(BaseModel):
@@ -33,7 +35,14 @@ class MergerTimelineElement(BaseModel):
 
 
 class MergerParticipant(CompanyIdAndName):
+    percent_ownership: Decimal | None
     advisors: list[AdvisorResp] | None
+
+
+class MergerDetails(BaseModel):
+    buy_side_termination_fee: Decimal | None
+    sell_side_termination_fee: Decimal | None
+    comment: str | None
 
 
 class MergerParticipants(BaseModel):
@@ -55,6 +64,20 @@ class MergerConsideration(BaseModel):
     current_calculated_gross_total_transaction_value: Decimal | None = None
     current_calculated_implied_equity_value: Decimal | None = None
     current_calculated_implied_enterprise_value: Decimal | None = None
+    presentation_gross_total_transaction_value: Decimal | None = None
+    presentation_implied_equity_value: Decimal | None = None
+    presentation_implied_enterprise_value: Decimal | None = None
+    target_stock_premium_1_day_prior: Decimal | None = None
+    target_stock_premium_7_days_prior: Decimal | None = None
+    target_stock_premium_30_days_prior: Decimal | None = None
+    current_calculated_tev_ebit: Decimal | None = None
+    current_calculated_tev_ebitda: Decimal | None = None
+    current_calculated_tev_revenues: Decimal | None = None
+    current_calculated_equity_net_income: Decimal | None = None
+    presentation_tev_ebit: Decimal | None = None
+    presentation_tev_ebitda: Decimal | None = None
+    presentation_tev_revenues: Decimal | None = None
+    presentation_equity_net_income: Decimal | None = None
     details: list[MergerConsiderationDetail]
 
 
@@ -62,6 +85,7 @@ class MergerInfo(BaseModel):
     timeline: list[MergerTimelineElement]
     participants: MergerParticipants
     consideration: MergerConsideration | None = None
+    details: MergerDetails | None
 
 
 class NoMergerFound(BaseModel):

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
@@ -87,6 +87,9 @@ class GetMergersInfoFromTransactionIdsArgs(BaseModel):
     include_advisors: bool = Field(
         default=False, description="Whether to include advisors for participants in the response"
     )
+    include_comments: bool = Field(
+        default=False, description="Whether to include transaction comments in the response"
+    )
 
 
 class GetMergersInfoFromTransactionIds(KfinanceTool):
@@ -111,21 +114,25 @@ class GetMergersInfoFromTransactionIds(KfinanceTool):
         # Function 1 returns all M&A's that involved Vodafone. Extract the <transaction_id> from the response where Vodafone was the buyer and Mannesmann was the target.
         Function 2: get_mergers_info_from_transaction_ids(transaction_ids=[<transaction_id>])
 
-        Query: "List Microsoft's acquisitions over $5 billion announced since 2020, along with the advisors for the acquisitions."
+        Query: "List Microsoft's acquisitions over $5 billion announced since 2020, along with the advisors and comments for the acquisitions."
         Function 1: get_mergers_from_identifiers(identifiers=["Microsoft"], start_date="2020-01-01")
-        # Function 1 returns transactions where Microsoft was the buyer, each with a transaction_id. Deal value and announcement date are NOT in that response, so call get_mergers_info_from_transaction_ids, passing in EVERY candidate transaction_id to check the $5B threshold, the announcement date, and advisors.
-        Function 2: get_mergers_info_from_transaction_ids(transaction_ids=[<transaction_id_1>, <transaction_id_2>, <transaction_id_3>], include_advisors=True)
+        # Function 1 returns transactions where Microsoft was the buyer, each with a transaction_id. Deal value and announcement date are NOT in that response, so call get_mergers_info_from_transaction_ids, passing in EVERY candidate transaction_id to check the $5B threshold, the announcement date, advisors, and comments.
+        Function 2: get_mergers_info_from_transaction_ids(transaction_ids=[<transaction_id_1>, <transaction_id_2>, <transaction_id_3>], include_advisors=True, include_comments=True)
     """).strip()
     args_schema: Type[BaseModel] = GetMergersInfoFromTransactionIdsArgs
     accepted_permissions: set[Permission] | None = {Permission.MergersPermission}
 
     async def _arun(
-        self, transaction_ids: list[int], include_advisors: bool = False
+        self,
+        transaction_ids: list[int],
+        include_advisors: bool = False,
+        include_comments: bool = False,
     ) -> MergersInfo:
         """"""
         return await get_mergers_info_from_transaction_ids(
             transaction_ids=transaction_ids,
             include_advisors=include_advisors,
+            include_comments=include_comments,
             httpx_client=self.kfinance_client.httpx_client,
         )
 
@@ -192,12 +199,17 @@ async def fetch_mergers_from_company_id(
 async def get_mergers_info_from_transaction_ids(
     transaction_ids: list[int],
     include_advisors: bool,
+    include_comments: bool,
     httpx_client: httpx.AsyncClient,
 ) -> MergersInfo:
     """Fetch detailed merger info for a transaction ID."""
     resp = await httpx_client.post(
         url="/mergers/info",
-        json={"transaction_ids": transaction_ids, "include_advisors": include_advisors},
+        json={
+            "transaction_ids": transaction_ids,
+            "include_advisors": include_advisors,
+            "include_comments": include_comments,
+        },
     )
     resp.raise_for_status()
     return MergersInfo.model_validate(resp.json())

--- a/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/merger_and_acquisition_tools.py
@@ -95,7 +95,7 @@ class GetMergersInfoFromTransactionIdsArgs(BaseModel):
 class GetMergersInfoFromTransactionIds(KfinanceTool):
     name: str = "get_mergers_info_from_transaction_ids"
     description: str = dedent("""
-        Provides comprehensive information about merger or acquisition transactions, including their timeline (announced date, closed date), participants' company_names, company_ids, and advisors if advisors are requested (participants are categorized as target, buyers, sellers), and financial consideration details (including monetary values).
+        Provides comprehensive information about merger or acquisition transactions, including their timeline (announced date, closed date), participants' company_names, company_ids, and advisors if advisors are requested (participants are categorized as target, buyers, sellers), financial consideration details (including monetary values), and high-level merger details (including a comment about the merger if comments are requested).
 
         Use this tool for questions about announcement dates, deal/transaction values or amounts paid, completion status, and transaction details.
 
@@ -114,9 +114,9 @@ class GetMergersInfoFromTransactionIds(KfinanceTool):
         # Function 1 returns all M&A's that involved Vodafone. Extract the <transaction_id> from the response where Vodafone was the buyer and Mannesmann was the target.
         Function 2: get_mergers_info_from_transaction_ids(transaction_ids=[<transaction_id>])
 
-        Query: "List Microsoft's acquisitions over $5 billion announced since 2020, along with the advisors and comments for the acquisitions."
+        Query: "List Microsoft's acquisitions over $5 billion announced since 2020, along with the advisors and context for the acquisitions."
         Function 1: get_mergers_from_identifiers(identifiers=["Microsoft"], start_date="2020-01-01")
-        # Function 1 returns transactions where Microsoft was the buyer, each with a transaction_id. Deal value and announcement date are NOT in that response, so call get_mergers_info_from_transaction_ids, passing in EVERY candidate transaction_id to check the $5B threshold, the announcement date, advisors, and comments.
+        # Function 1 returns transactions where Microsoft was the buyer, each with a transaction_id. Deal value and announcement date are NOT in that response, so call get_mergers_info_from_transaction_ids, passing in EVERY candidate transaction_id to check the $5B threshold, the announcement date, and advisors. Use include_comments to include a comment that provides additional details and context for each transaction.
         Function 2: get_mergers_info_from_transaction_ids(transaction_ids=[<transaction_id_1>, <transaction_id_2>, <transaction_id_3>], include_advisors=True, include_comments=True)
     """).strip()
     args_schema: Type[BaseModel] = GetMergersInfoFromTransactionIdsArgs

--- a/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
+++ b/kfinance/domains/mergers_and_acquisitions/tests/test_merger_and_acquisition_tools.py
@@ -129,13 +129,33 @@ class TestMergersAndAcquisitions:
             {"status": "Closed", "date": "2000-09-12"},
         ]
         participants_resp = {
-            "target": {"company_id": 31696, "company_name": "MongoMusic, Inc.", "advisors": None},
+            "target": {
+                "company_id": 31696,
+                "company_name": "MongoMusic, Inc.",
+                "percent_ownership": None,
+                "advisors": [],
+            },
             "buyers": [
-                {"company_id": 21835, "company_name": "Microsoft Corporation", "advisors": None}
+                {
+                    "company_id": 21835,
+                    "company_name": "Microsoft Corporation",
+                    "percent_ownership": "100.00",
+                    "advisors": [],
+                }
             ],
             "sellers": [
-                {"company_id": 18805, "company_name": "Angel Investors L.P.", "advisors": None},
-                {"company_id": 20087, "company_name": "Draper Richards, L.P.", "advisors": None},
+                {
+                    "company_id": 18805,
+                    "company_name": "Angel Investors L.P.",
+                    "percent_ownership": None,
+                    "advisors": [],
+                },
+                {
+                    "company_id": 20087,
+                    "company_name": "Draper Richards, L.P.",
+                    "percent_ownership": None,
+                    "advisors": [],
+                },
             ],
         }
         consideration_resp = {
@@ -143,6 +163,20 @@ class TestMergersAndAcquisitions:
             "current_calculated_gross_total_transaction_value": "51609375.000000",
             "current_calculated_implied_equity_value": "51609375.000000",
             "current_calculated_implied_enterprise_value": "51609375.000000",
+            "presentation_gross_total_transaction_value": "51609375.000000",
+            "presentation_implied_equity_value": "51609375.000000",
+            "presentation_implied_enterprise_value": "51609375.000000",
+            "target_stock_premium_1_day_prior": None,
+            "target_stock_premium_7_days_prior": None,
+            "target_stock_premium_30_days_prior": None,
+            "current_calculated_tev_ebit": None,
+            "current_calculated_tev_ebitda": None,
+            "current_calculated_tev_revenues": None,
+            "current_calculated_equity_net_income": None,
+            "presentation_tev_ebit": None,
+            "presentation_tev_ebitda": None,
+            "presentation_tev_revenues": None,
+            "presentation_equity_net_income": None,
             "details": [
                 {
                     "scenario": "Stock Lump Sum",
@@ -153,6 +187,11 @@ class TestMergersAndAcquisitions:
                 }
             ],
         }
+        details_resp = {
+            "buy_side_termination_fee": None,
+            "sell_side_termination_fee": None,
+            "comment": "Microsoft Corp. (Nasdaq: MSFT) acquired MongoMusic Inc. for approximately $51.6 million in stock on October 12, 2000.",
+        }
 
         error_resp = f"No merger found for transaction_id: {error_transaction_id}"
 
@@ -162,6 +201,7 @@ class TestMergersAndAcquisitions:
             match_json={
                 "transaction_ids": [transaction_id, error_transaction_id],
                 "include_advisors": True,
+                "include_comments": True,
             },
             json={
                 "results": {
@@ -169,6 +209,7 @@ class TestMergersAndAcquisitions:
                         "timeline": timeline_resp,
                         "participants": participants_resp,
                         "consideration": consideration_resp,
+                        "details": details_resp,
                     },
                     error_transaction_id: {"error": error_resp},
                 }
@@ -182,6 +223,7 @@ class TestMergersAndAcquisitions:
                         "timeline": timeline_resp,
                         "participants": participants_resp,
                         "consideration": consideration_resp,
+                        "details": details_resp,
                     },
                     error_transaction_id: {"error": error_resp},
                 }
@@ -191,6 +233,7 @@ class TestMergersAndAcquisitions:
         resp = await get_mergers_info_from_transaction_ids(
             transaction_ids=[transaction_id, error_transaction_id],
             include_advisors=True,
+            include_comments=True,
             httpx_client=httpx_client,
         )
 


### PR DESCRIPTION
The API was recently updated to add new data to the `api/v1/mergers/info` endpoint, including more merger consideration data items, advisor fee data, and participant percentage ownership. In this PR, the `get_mergers_info_from_transaction_ids` tool call response is updated to include this data. The comments data is gated by an `include_comments` parameter.