### PR TITLE
Fix swapped dataitemid/spgi_name for gain from sale line items

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v7.0.3
+- Fix swapped `dataitemid`/`spgi_name` for `gain_from_sale_of_assets` and
+  `gain_from_sale_of_investments` line item metadata.
+
 ## v7.0.2
 - Modify GetIssuerRatingsFromIdentifiers tool description.
 

--- a/kfinance/domains/line_items/line_item_models.py
+++ b/kfinance/domains/line_items/line_item_models.py
@@ -409,15 +409,15 @@ LINE_ITEMS: list[LineItemType] = [
     {
         "name": "gain_from_sale_of_assets",
         "aliases": set(),
-        "dataitemid": 62,
-        "spgi_name": "Gain (Loss) On Sale Of Invest.",
+        "dataitemid": 56,
+        "spgi_name": "Gain (Loss) On Sale Of Assets",
         "description": "Gain recognized from disposing tangible or intangible assets.",
     },
     {
         "name": "gain_from_sale_of_investments",
         "aliases": set(),
-        "dataitemid": 56,
-        "spgi_name": "Gain (Loss) On Sale Of Assets",
+        "dataitemid": 62,
+        "spgi_name": "Gain (Loss) On Sale Of Invest.",
         "description": "Gain realized from selling investment holdings.",
     },
     {

--- a/kfinance/domains/line_items/tests/test_line_item_tools.py
+++ b/kfinance/domains/line_items/tests/test_line_item_tools.py
@@ -358,3 +358,14 @@ class TestFindSimilarLineItems:
             assert isinstance(item.score, float)
             assert item.name in self.TEST_DESCRIPTORS
             assert item.description == self.TEST_DESCRIPTORS[item.name]
+
+
+def test_sale_line_item_dataitemids_not_swapped() -> None:
+    # ponytail: regression guard for the assets/investments swap (dataitemids 56/62)
+    from kfinance.domains.line_items.line_item_models import LINE_ITEMS
+
+    by_name = {item["name"]: item for item in LINE_ITEMS}
+    assets = by_name["gain_from_sale_of_assets"]
+    invest = by_name["gain_from_sale_of_investments"]
+    assert (assets["dataitemid"], assets["spgi_name"]) == (56, "Gain (Loss) On Sale Of Assets")
+    assert (invest["dataitemid"], invest["spgi_name"]) == (62, "Gain (Loss) On Sale Of Invest.")


### PR DESCRIPTION
## Summary
- `gain_from_sale_of_assets` and `gain_from_sale_of_investments` had their `dataitemid`/`spgi_name` cross-wired. Per the CIQ data dictionary, `56` = Gain (Loss) On Sale Of Assets and `62` = Gain (Loss) On Sale Of Investments, but assets pointed at `62` and investments at `56`.
- In this client SDK these fields only feed docstrings/descriptions (the client sends the line-item *name* string; the server owns `name -> dataitemid -> SQL`), so this corrects the metadata surfaced to agents — it does **not** change returned numbers.
- Added `test_sale_line_item_dataitemids_not_swapped` to guard both mappings (no test previously pinned these, which is why the swap — present since the original commit — went unnoticed).
- Smallest possible version bump: patch `v7.1.1` (version is git-tag derived via setuptools_scm, so only the CHANGELOG entry is added).

## Note for maintainers
The authoritative numeric fix lives in the **server** repo's constants map (name -> dataitemid -> SQL). This PR only fixes client-side metadata. The revenue pair (`revenue_from_sale_of_assets` 104 / `revenue_from_sale_of_investments` 106) was verified already-correct and left untouched.

## Test plan
- [x] `uv run pytest kfinance/domains/line_items/tests/test_line_item_tools.py::test_sale_line_item_dataitemids_not_swapped`