### PR TITLE
Add optional kid to client keypair auth

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.2.0
+- Add optional `kid` parameter to `Client`, stamped on the private-key-JWT client assertion so
+  users with more than one active public key (e.g. mid key-rotation) can authenticate.
+
 ## 7.1.0
 - Add additional data items to `get_mergers_info_from_transaction_ids` tool call response.
 - Add `include_comments` parameter to `get_mergers_info_from_transaction_ids` tool call.

--- a/kfinance/client/fetch.py
+++ b/kfinance/client/fetch.py
@@ -84,6 +84,7 @@ class KFinanceApiClient:
         refresh_token: Optional[str] = None,
         client_id: Optional[str] = None,
         private_key: Optional[str] = None,
+        kid: Optional[str] = None,
         thread_pool: Optional[ThreadPoolExecutor] = None,
         api_host: str = DEFAULT_API_HOST,
         api_version: int = DEFAULT_API_VERSION,
@@ -98,6 +99,8 @@ class KFinanceApiClient:
         :type client_id: str, Optional
         :param private_key: users private key that corresponds to the registered public sent to support@kensho.com
         :type private_key: str, Optional
+        :param kid: key ID of the registered public key, required when more than one key is active
+        :type kid: str, Optional
         :param thread_pool: the thread pool used to execute batch requests. The number of concurrent requests is
         capped at 10. If no thread pool is provided, a thread pool with 10 max workers will be created when batch
         requests are made.
@@ -119,6 +122,7 @@ class KFinanceApiClient:
         elif client_id is not None and private_key is not None:
             self.client_id = client_id
             self.private_key = private_key
+            self.kid = kid
             self._access_token_refresh_func = self._get_access_token_via_keypair
         else:
             raise RuntimeError("No credentials for any authentication strategy were provided")
@@ -202,6 +206,7 @@ class KFinanceApiClient:
             },
             self.private_key,
             algorithm="RS256",
+            headers={"kid": self.kid} if self.kid else None,
         )
         response = requests.post(
             f"{self.okta_host}/oauth2/{self.okta_auth_server}/v1/token",

--- a/kfinance/client/kfinance.py
+++ b/kfinance/client/kfinance.py
@@ -1802,6 +1802,7 @@ class Client:
         refresh_token: Optional[str] = None,
         client_id: Optional[str] = None,
         private_key: Optional[str] = None,
+        kid: Optional[str] = None,
         thread_pool: Optional[ThreadPoolExecutor] = None,
         api_host: str = DEFAULT_API_HOST,
         api_version: int = DEFAULT_API_VERSION,
@@ -1816,6 +1817,8 @@ class Client:
         :type client_id: str, Optional
         :param private_key: users private key that corresponds to the registered public sent to support@kensho.com
         :type private_key: str, Optional
+        :param kid: key ID of the registered public key, required when more than one key is active
+        :type kid: str, Optional
         :param thread_pool: the thread pool used to execute batch requests. The number of concurrent requests is
         capped at 10. If no thread pool is provided, a thread pool with 10 max workers will be created when batch
         requests are made.
@@ -1844,6 +1847,7 @@ class Client:
             self.kfinance_api_client = KFinanceApiClient(
                 client_id=client_id,
                 private_key=private_key,
+                kid=kid,
                 api_host=api_host,
                 api_version=api_version,
                 okta_host=okta_host,

--- a/kfinance/client/tests/test_fetch.py
+++ b/kfinance/client/tests/test_fetch.py
@@ -1,6 +1,9 @@
 from unittest import TestCase
 from unittest.mock import MagicMock
 
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+import jwt
 from pydantic import ValidationError
 import pytest
 from requests_mock import Mocker
@@ -760,3 +763,36 @@ class TestFetchIssuerRatings:
         assert "21719" in resp.results
         assert "21835" in resp.results
         assert resp.errors == {}
+
+
+class TestKeypairAssertionKid:
+    """The client assertion built by keypair auth carries the kid header when set."""
+
+    TOKEN_URL = "https://kensho.okta.com/oauth2/default/v1/token"
+
+    @staticmethod
+    def _private_key_pem() -> str:
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        return key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode()
+
+    def _captured_assertion(self, requests_mock: Mocker, kid: str | None) -> str:
+        requests_mock.post(url=self.TOKEN_URL, json={"access_token": "fake_token"})
+        client = KFinanceApiClient(
+            client_id="testapp", private_key=self._private_key_pem(), kid=kid
+        )
+        client._get_access_token_via_keypair()  # noqa: SLF001
+        request_body = requests_mock.last_request.text
+        assertion = dict(pair.split("=", 1) for pair in request_body.split("&"))["client_assertion"]
+        return assertion
+
+    def test_assertion_stamps_kid_header(self, requests_mock: Mocker) -> None:
+        assertion = self._captured_assertion(requests_mock, kid="my-key-id")
+        assert jwt.get_unverified_header(assertion)["kid"] == "my-key-id"
+
+    def test_assertion_omits_kid_header_when_unset(self, requests_mock: Mocker) -> None:
+        assertion = self._captured_assertion(requests_mock, kid=None)
+        assert "kid" not in jwt.get_unverified_header(assertion)


### PR DESCRIPTION
Thread an optional `kid` through `Client` and `KFinanceApiClient` so the private-key-JWT client assertion carries the signing keys `kid`. This lets a user with more than one active public key (e.g. mid key-rotation) authenticate. Backward-compatible: with no `kid` the assertion is unchanged.

Verified against an Okta private-key-JWT app: with two keys registered, an assertion with no `kid` fails (`401 invalid_client: kid is invalid`) and one carrying the matching `kid` passes client authentication. Added unit tests asserting the `kid` header is stamped when set and omitted when unset; `ruff`, `mypy`, and the client test suite pass locally.