### PR TITLE
Remove after quarter model validation

### DIFF
--- a/kfinance/CHANGELOG.md
+++ b/kfinance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.1.1
+- Fix quarter parameter type mismatch: remove `AfterValidator` from `ValidQuarter` so `model_dump()` on MCP server side outputs strings.
+
 ## 7.1.0
 - Add additional data items to `get_mergers_info_from_transaction_ids` tool call response.
 - Add `include_comments` parameter to `get_mergers_info_from_transaction_ids` tool call.

--- a/kfinance/domains/estimates/estimates_tools.py
+++ b/kfinance/domains/estimates/estimates_tools.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from textwrap import dedent
-from typing import Literal, Type
+from typing import Literal, Type, cast
 
 import httpx
 from pydantic import BaseModel, Field
@@ -86,8 +86,8 @@ class GetEstimatesFromIdentifiers(KfinanceTool, ABC):
         period_type: EstimatePeriodType | None = None,
         fiscal_start_year: int | None = None,
         fiscal_end_year: int | None = None,
-        fiscal_start_quarter: Literal[1, 2, 3, 4] | None = None,
-        fiscal_end_quarter: Literal[1, 2, 3, 4] | None = None,
+        fiscal_start_quarter: Literal["1", "2", "3", "4"] | None = None,
+        fiscal_end_quarter: Literal["1", "2", "3", "4"] | None = None,
         num_periods_forward: int | None = None,
         num_periods_backward: int | None = None,
     ) -> GetCiqEstimatesFromIdentifiersResp:
@@ -99,8 +99,12 @@ class GetEstimatesFromIdentifiers(KfinanceTool, ABC):
             period_type=period_type,
             fiscal_start_year=fiscal_start_year,
             fiscal_end_year=fiscal_end_year,
-            fiscal_start_quarter=fiscal_start_quarter,
-            fiscal_end_quarter=fiscal_end_quarter,
+            fiscal_start_quarter=cast(Literal[1, 2, 3, 4], int(fiscal_start_quarter))
+            if fiscal_start_quarter
+            else None,
+            fiscal_end_quarter=cast(Literal[1, 2, 3, 4], int(fiscal_end_quarter))
+            if fiscal_end_quarter
+            else None,
             num_periods_forward=num_periods_forward,
             num_periods_backward=num_periods_backward,
         )

--- a/kfinance/domains/estimates/estimates_tools_va.py
+++ b/kfinance/domains/estimates/estimates_tools_va.py
@@ -1,5 +1,5 @@
 from textwrap import dedent
-from typing import Any, Literal, Type
+from typing import Any, Literal, Type, cast
 
 import httpx
 from pydantic import BaseModel, Field
@@ -95,8 +95,8 @@ class GetVisibleAlphaConsensusEstimatesFromIdentifiers(KfinanceTool):
         period_type: EstimatePeriodType | None = None,
         start_year: int | None = None,
         end_year: int | None = None,
-        start_quarter: Literal[1, 2, 3, 4] | None = None,
-        end_quarter: Literal[1, 2, 3, 4] | None = None,
+        start_quarter: Literal["1", "2", "3", "4"] | None = None,
+        end_quarter: Literal["1", "2", "3", "4"] | None = None,
         num_periods_forward: int | None = None,
         num_periods_backward: int | None = None,
         estimate_search: str | None = None,
@@ -110,8 +110,8 @@ class GetVisibleAlphaConsensusEstimatesFromIdentifiers(KfinanceTool):
             period_type=period_type,
             start_year=start_year,
             end_year=end_year,
-            start_quarter=start_quarter,
-            end_quarter=end_quarter,
+            start_quarter=cast(Literal[1, 2, 3, 4], int(start_quarter)) if start_quarter else None,
+            end_quarter=cast(Literal[1, 2, 3, 4], int(end_quarter)) if end_quarter else None,
             num_periods_forward=num_periods_forward,
             num_periods_backward=num_periods_backward,
             estimate_search=estimate_search,

--- a/kfinance/domains/line_items/line_item_tools.py
+++ b/kfinance/domains/line_items/line_item_tools.py
@@ -1,6 +1,6 @@
 from difflib import SequenceMatcher
 from textwrap import dedent
-from typing import Any, Literal, Type
+from typing import Any, Literal, Type, cast
 
 import httpx
 from pydantic import BaseModel, Field, model_validator
@@ -198,8 +198,8 @@ class GetFinancialLineItemFromIdentifiers(KfinanceTool):
         period_type: PeriodType | None = None,
         start_year: int | None = None,
         end_year: int | None = None,
-        start_quarter: Literal[1, 2, 3, 4] | None = None,
-        end_quarter: Literal[1, 2, 3, 4] | None = None,
+        start_quarter: Literal["1", "2", "3", "4"] | None = None,
+        end_quarter: Literal["1", "2", "3", "4"] | None = None,
         calendar_type: CalendarType | None = None,
         num_periods: int | None = None,
         num_periods_back: int | None = None,
@@ -212,8 +212,8 @@ class GetFinancialLineItemFromIdentifiers(KfinanceTool):
             period_type=period_type,
             start_year=start_year,
             end_year=end_year,
-            start_quarter=start_quarter,
-            end_quarter=end_quarter,
+            start_quarter=cast(Literal[1, 2, 3, 4], int(start_quarter)) if start_quarter else None,
+            end_quarter=cast(Literal[1, 2, 3, 4], int(end_quarter)) if end_quarter else None,
             calendar_type=calendar_type,
             num_periods=num_periods,
             num_periods_back=num_periods_back,

--- a/kfinance/domains/line_items/line_item_tools_va.py
+++ b/kfinance/domains/line_items/line_item_tools_va.py
@@ -1,5 +1,5 @@
 from textwrap import dedent
-from typing import Any, Literal, Type
+from typing import Any, Literal, Type, cast
 
 import httpx
 from pydantic import BaseModel, Field
@@ -82,8 +82,8 @@ class GetVisibleAlphaFinancialLineItemFromIdentifiers(KfinanceTool):
         period_type: EstimatePeriodType | None = None,
         start_year: int | None = None,
         end_year: int | None = None,
-        start_quarter: Literal[1, 2, 3, 4] | None = None,
-        end_quarter: Literal[1, 2, 3, 4] | None = None,
+        start_quarter: Literal["1", "2", "3", "4"] | None = None,
+        end_quarter: Literal["1", "2", "3", "4"] | None = None,
         calendar_type: CalendarType | None = None,
         num_periods: int | None = None,
         num_periods_back: int | None = None,
@@ -97,8 +97,8 @@ class GetVisibleAlphaFinancialLineItemFromIdentifiers(KfinanceTool):
             period_type=period_type,
             start_year=start_year,
             end_year=end_year,
-            start_quarter=start_quarter,
-            end_quarter=end_quarter,
+            start_quarter=cast(Literal[1, 2, 3, 4], int(start_quarter)) if start_quarter else None,
+            end_quarter=cast(Literal[1, 2, 3, 4], int(end_quarter)) if end_quarter else None,
             calendar_type=calendar_type,
             num_periods=num_periods,
             num_periods_back=num_periods_back,

--- a/kfinance/domains/segments/segment_tools.py
+++ b/kfinance/domains/segments/segment_tools.py
@@ -1,5 +1,5 @@
 from textwrap import dedent
-from typing import Any, Literal, Type
+from typing import Any, Literal, Type, cast
 
 import httpx
 from pydantic import BaseModel, Field
@@ -82,8 +82,8 @@ class GetSegmentsFromIdentifiers(KfinanceTool):
         period_type: PeriodType | None = None,
         start_year: int | None = None,
         end_year: int | None = None,
-        start_quarter: Literal[1, 2, 3, 4] | None = None,
-        end_quarter: Literal[1, 2, 3, 4] | None = None,
+        start_quarter: Literal["1", "2", "3", "4"] | None = None,
+        end_quarter: Literal["1", "2", "3", "4"] | None = None,
         calendar_type: CalendarType | None = None,
         num_periods: int | None = None,
         num_periods_back: int | None = None,
@@ -95,8 +95,8 @@ class GetSegmentsFromIdentifiers(KfinanceTool):
             period_type=period_type,
             start_year=start_year,
             end_year=end_year,
-            start_quarter=start_quarter,
-            end_quarter=end_quarter,
+            start_quarter=cast(Literal[1, 2, 3, 4], int(start_quarter)) if start_quarter else None,
+            end_quarter=cast(Literal[1, 2, 3, 4], int(end_quarter)) if end_quarter else None,
             calendar_type=calendar_type,
             num_periods=num_periods,
             num_periods_back=num_periods_back,

--- a/kfinance/domains/segments/segment_tools_va.py
+++ b/kfinance/domains/segments/segment_tools_va.py
@@ -1,5 +1,5 @@
 from textwrap import dedent
-from typing import Any, Literal, Type
+from typing import Any, Literal, Type, cast
 
 import httpx
 from pydantic import BaseModel, Field
@@ -65,8 +65,8 @@ class GetVisibleAlphaSegmentsFromIdentifiers(KfinanceTool):
         period_type: EstimatePeriodType | None = None,
         start_year: int | None = None,
         end_year: int | None = None,
-        start_quarter: Literal[1, 2, 3, 4] | None = None,
-        end_quarter: Literal[1, 2, 3, 4] | None = None,
+        start_quarter: Literal["1", "2", "3", "4"] | None = None,
+        end_quarter: Literal["1", "2", "3", "4"] | None = None,
         calendar_type: CalendarType | None = None,
         num_periods: int | None = None,
         num_periods_back: int | None = None,
@@ -80,8 +80,8 @@ class GetVisibleAlphaSegmentsFromIdentifiers(KfinanceTool):
             period_type=period_type,
             start_year=start_year,
             end_year=end_year,
-            start_quarter=start_quarter,
-            end_quarter=end_quarter,
+            start_quarter=cast(Literal[1, 2, 3, 4], int(start_quarter)) if start_quarter else None,
+            end_quarter=cast(Literal[1, 2, 3, 4], int(end_quarter)) if end_quarter else None,
             calendar_type=calendar_type,
             num_periods=num_periods,
             num_periods_back=num_periods_back,

--- a/kfinance/domains/statements/statement_tools.py
+++ b/kfinance/domains/statements/statement_tools.py
@@ -1,5 +1,5 @@
 from textwrap import dedent
-from typing import Any, Literal, Type
+from typing import Any, Literal, Type, cast
 
 import httpx
 from pydantic import BaseModel, Field
@@ -101,8 +101,8 @@ class GetFinancialStatementFromIdentifiers(KfinanceTool):
         period_type: PeriodType | None = None,
         start_year: int | None = None,
         end_year: int | None = None,
-        start_quarter: Literal[1, 2, 3, 4] | None = None,
-        end_quarter: Literal[1, 2, 3, 4] | None = None,
+        start_quarter: Literal["1", "2", "3", "4"] | None = None,
+        end_quarter: Literal["1", "2", "3", "4"] | None = None,
         calendar_type: CalendarType | None = None,
         num_periods: int | None = None,
         num_periods_back: int | None = None,
@@ -114,8 +114,8 @@ class GetFinancialStatementFromIdentifiers(KfinanceTool):
             period_type=period_type,
             start_year=start_year,
             end_year=end_year,
-            start_quarter=start_quarter,
-            end_quarter=end_quarter,
+            start_quarter=cast(Literal[1, 2, 3, 4], int(start_quarter)) if start_quarter else None,
+            end_quarter=cast(Literal[1, 2, 3, 4], int(end_quarter)) if end_quarter else None,
             calendar_type=calendar_type,
             num_periods=num_periods,
             num_periods_back=num_periods_back,

--- a/kfinance/integrations/tool_calling/tests/test_tool_calling_models.py
+++ b/kfinance/integrations/tool_calling/tests/test_tool_calling_models.py
@@ -115,27 +115,36 @@ class TestValidQuarter:
     @pytest.mark.parametrize(
         "input_quarter, expectation, expected_quarter",
         [
-            pytest.param(1, does_not_raise(), 1, id="int input works"),
-            pytest.param("1", does_not_raise(), 1, id="str input works"),
+            pytest.param(1, does_not_raise(), "1", id="int input coerced to str"),
+            pytest.param("1", does_not_raise(), "1", id="str input stays str"),
             pytest.param(None, does_not_raise(), None, id="None input works"),
             pytest.param(5, pytest.raises(ValidationError), None, id="invalid int raises"),
             pytest.param("5", pytest.raises(ValidationError), None, id="invalid str raises"),
+            pytest.param(0, pytest.raises(ValidationError), None, id="zero raises"),
+            pytest.param("abc", pytest.raises(ValidationError), None, id="non-digit str raises"),
         ],
     )
     def test_valid_quarter(
         self,
         input_quarter: int | str | None,
         expectation: contextlib.AbstractContextManager,
-        expected_quarter: int | None,
+        expected_quarter: str | None,
     ) -> None:
         """
         GIVEN a model that uses `ValidQuarter`
         WHEN we deserialize with int, str, or None
-        THEN valid str get coerced to int. Invalid values raise.
+        THEN valid inputs are converted as str. Invalid values raise.
         """
         with expectation:
             res = self.QuarterModel.model_validate(dict(quarter=input_quarter))
             assert res.quarter == expected_quarter
+
+    @pytest.mark.parametrize("input_quarter", [1, 2, 3, 4, "1", "2", "3", "4"])
+    def test_model_dump_outputs_string(self, input_quarter: int | str) -> None:
+        """Ensure model_dump() outputs is always string."""
+        res = self.QuarterModel.model_validate(dict(quarter=input_quarter))
+        dumped = res.model_dump()
+        assert isinstance(dumped["quarter"], str)
 
 
 class TestRunSyncAndAsync:

--- a/kfinance/integrations/tool_calling/tool_calling_models.py
+++ b/kfinance/integrations/tool_calling/tool_calling_models.py
@@ -6,7 +6,6 @@ from asyncer import syncify
 from httpx import HTTPStatusError
 from langchain_core.tools import BaseTool
 from pydantic import (
-    AfterValidator,
     BaseModel,
     BeforeValidator,
     ConfigDict,
@@ -176,13 +175,6 @@ class ToolArgsWithIdentifiers(BaseModel):
         return v
 
 
-def convert_str_to_int(v: Any) -> Any:
-    """Convert strings to integers if possible."""
-    if isinstance(v, str) and v.isdigit():
-        return int(v)
-    return v
-
-
 def convert_int_to_str(v: Any) -> Any:
     """Convert integers to strings if possible."""
     if isinstance(v, int):
@@ -197,11 +189,9 @@ def convert_int_to_str(v: Any) -> Any:
 
 # TODO(LRA-304): Revert following fix after Gemini schema leniency feature is implemented.
 # BeforeValidator: convert possible int to str before Literal validation.
-# AfterValidator: convert str back to int to stay consistent with internal kfinance logic.
 ValidQuarter = Annotated[
     Literal["1", "2", "3", "4"],
     BeforeValidator(convert_int_to_str),
-    AfterValidator(convert_str_to_int),
 ]
 
 


### PR DESCRIPTION
## Notes 

This PR fixes following Pydantic validation issue for quarter fields. It removed the automatic `AfterValidator` and changed to explicitly convert the literal enum type from `string` to `int` before processing the data. 

### More context

After recent [PR#139](https://github.com/kensho-technologies/kfinance/pull/139), the Pydantic model will be validated before passing args to server side for processing. It has side effect that will cause `AfterValidator` run for quarter fields (e.g., `start_quarter` field for financial line items MCP tool) and convert value to `int`, which will cause Pydantic validation error like below:

> 2 validation errors for call[get_line_item_from_identifiers_tool]
start_quarter
  Input should be '1', '2', '3' or '4' [type=literal_error, input_value=1, input_type=int]
    For further information visit https://errors.pydantic.dev/2.12/v/literal_error
end_quarter
  Input should be '1', '2', '3' or '4' [type=literal_error, input_value=1, input_type=int]
    For further information visit https://errors.pydantic.dev/2.12/v/literal_error